### PR TITLE
Fixed warnings in unit tests due to deprecated getMock() in phpunit 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OrangeHRM Open Source Application
 
-[![Docker Automated](https://img.shields.io/docker/automated/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Status](https://img.shields.io/docker/build/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Pulls](https://img.shields.io/docker/pulls/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm)  [![Travis Test](https://img.shields.io/travis/orangehrm/orangehrm/master.svg)](https://travis-ci.org/orangehrm/orangehrm)  [![SourceForge Downloads](https://img.shields.io/sourceforge/dm/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) [![SourceForge Downloads](https://img.shields.io/sourceforge/dt/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) 
+[![Docker Automated](https://img.shields.io/docker/automated/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Status](https://img.shields.io/docker/build/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Pulls](https://img.shields.io/docker/pulls/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm)  [![Travis Test](https://img.shields.io/travis/orangehrm/orangehrm/php7-dev.svg)](https://travis-ci.org/orangehrm/orangehrm)  [![SourceForge Downloads](https://img.shields.io/sourceforge/dm/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) [![SourceForge Downloads](https://img.shields.io/sourceforge/dt/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) 
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OrangeHRM Open Source Application
 
-[![Docker Automated](https://img.shields.io/docker/automated/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Status](https://img.shields.io/docker/build/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Pulls](https://img.shields.io/docker/pulls/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm)  [![Travis Test](https://img.shields.io/travis/orangehrm/orangehrm/php7-dev.svg)](https://travis-ci.org/orangehrm/orangehrm)  [![SourceForge Downloads](https://img.shields.io/sourceforge/dm/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) [![SourceForge Downloads](https://img.shields.io/sourceforge/dt/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) 
+[![Docker Automated](https://img.shields.io/docker/automated/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Status](https://img.shields.io/docker/build/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm/) [![Docker Pulls](https://img.shields.io/docker/pulls/orangehrm/orangehrm.svg)](https://hub.docker.com/r/orangehrm/orangehrm)  [![Travis Test](https://img.shields.io/travis/orangehrm/orangehrm/master.svg)](https://travis-ci.org/orangehrm/orangehrm)  [![SourceForge Downloads](https://img.shields.io/sourceforge/dm/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) [![SourceForge Downloads](https://img.shields.io/sourceforge/dt/orangehrm.svg)](https://sourceforge.net/projects/orangehrm/) 
 
 
 

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/CompanyStructureServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/CompanyStructureServiceTest.php
@@ -41,7 +41,7 @@ class CompanyStructureServiceTest extends PHPUnit_Framework_TestCase {
 
         $subunit = TestDataService::fetchObject('Subunit', 1);
 
-        $compStructureDao = $this->getMock('CompanyStructureDao');
+        $compStructureDao = $this->getMockBuilder('CompanyStructureDao')->getMock();
 
         $compStructureDao->expects($this->once())
                 ->method('getSubunitById')
@@ -58,7 +58,7 @@ class CompanyStructureServiceTest extends PHPUnit_Framework_TestCase {
         $subunit = new Subunit();
         $subunit->setName("subunit name");
 
-        $compStructureDao = $this->getMock('CompanyStructureDao');
+        $compStructureDao = $this->getMockBuilder('CompanyStructureDao')->getMock();
 
         $compStructureDao->expects($this->once())
                 ->method('saveSubunit')
@@ -77,7 +77,7 @@ class CompanyStructureServiceTest extends PHPUnit_Framework_TestCase {
         $parentSubunit = new Subunit();
         $parentSubunit->setName("new subunit");
 
-        $compStructureDao = $this->getMock('CompanyStructureDao');
+        $compStructureDao = $this->getMockBuilder('CompanyStructureDao')->getMock();
 
         $compStructureDao->expects($this->once())
                 ->method('addSubunit')
@@ -96,7 +96,7 @@ class CompanyStructureServiceTest extends PHPUnit_Framework_TestCase {
         $parentSubunit = new Subunit();
         $parentSubunit->setName("new subunit");
 
-        $compStructureDao = $this->getMock('CompanyStructureDao');
+        $compStructureDao = $this->getMockBuilder('CompanyStructureDao')->getMock();
 
         $compStructureDao->expects($this->once())
                 ->method('deleteSubunit')
@@ -113,7 +113,7 @@ class CompanyStructureServiceTest extends PHPUnit_Framework_TestCase {
         $name = "Company Name";
         $returnvalue = 1;
 
-        $compStructureDao = $this->getMock('CompanyStructureDao');
+        $compStructureDao = $this->getMockBuilder('CompanyStructureDao')->getMock();
 
         $compStructureDao->expects($this->once())
                 ->method('setOrganizationName')
@@ -129,7 +129,7 @@ class CompanyStructureServiceTest extends PHPUnit_Framework_TestCase {
 
         $treeObject = Doctrine::getTable('Subunit')->getTree();
 
-        $compStructureDao = $this->getMock('CompanyStructureDao');
+        $compStructureDao = $this->getMockBuilder('CompanyStructureDao')->getMock();
 
         $compStructureDao->expects($this->once())
                 ->method('getSubunitTreeObject')

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/CountryServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/CountryServiceTest.php
@@ -63,7 +63,9 @@ class CountryServiceTest extends PHPUnit_Framework_TestCase {
             'sampleParam2' => 'sampleValue2',
         );
         
-        $countryDaoMock = $this->getMock('CountryDao', array('searchCountries'));
+        $countryDaoMock = $this->getMockBuilder('CountryDao')
+			->setMethods( array('searchCountries'))
+			->getMock();
         $countryDaoMock->expects($this->once())
                 ->method('searchCountries')
                 ->will($this->returnValue($countries));
@@ -83,7 +85,9 @@ class CountryServiceTest extends PHPUnit_Framework_TestCase {
             'sampleParam2' => 'sampleValue2',
         );
         
-        $countryDaoMock = $this->getMock('CountryDao', array('searchCountries'));
+        $countryDaoMock = $this->getMockBuilder('CountryDao')
+			->setMethods( array('searchCountries'))
+			->getMock();
         $countryDaoMock->expects($this->once())
                 ->method('searchCountries')
                 ->will($this->throwException(new DaoException));

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/CustomerServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/CustomerServiceTest.php
@@ -41,7 +41,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
 
 		$customerList = TestDataService::loadObjectList('Customer', $this->fixture, 'Customer');
 
-		$customerDao = $this->getMock('CustomerDao');
+		$customerDao = $this->getMockBuilder('CustomerDao')->getMock();
 		$customerDao->expects($this->once())
 			->method('getCustomerList')
 			->with("","","","","")
@@ -55,7 +55,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
 	
 	public function testGetCustomerCount() {
 
-		$customerDao = $this->getMock('CustomerDao');
+		$customerDao = $this->getMockBuilder('CustomerDao')->getMock();
 		$customerDao->expects($this->once())
 			->method('getCustomerCount')
 			->with("")
@@ -71,7 +71,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
 
 		$customerList = TestDataService::loadObjectList('Customer', $this->fixture, 'Customer');
 
-		$customerDao = $this->getMock('CustomerDao');
+		$customerDao = $this->getMockBuilder('CustomerDao')->getMock();
 		$customerDao->expects($this->once())
 			->method('getCustomerById')
 			->with(1)
@@ -87,7 +87,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
 
 		$customerList = TestDataService::loadObjectList('Customer', $this->fixture, 'Customer');
 
-		$customerDao = $this->getMock('CustomerDao');
+		$customerDao = $this->getMockBuilder('CustomerDao')->getMock();
 		$customerDao->expects($this->once())
 			->method('deleteCustomer')
 			->with(1)
@@ -103,7 +103,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
 
 		$customerList = TestDataService::loadObjectList('Customer', $this->fixture, 'Customer');
 
-		$customerDao = $this->getMock('CustomerDao');
+		$customerDao = $this->getMockBuilder('CustomerDao')->getMock();
 		$customerDao->expects($this->once())
 			->method('getAllCustomers')
 			->with(false)
@@ -117,7 +117,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
 	
 	public function testHasCustomerGotTimesheetItems() {
 
-		$customerDao = $this->getMock('CustomerDao');
+		$customerDao = $this->getMockBuilder('CustomerDao')->getMock();
 		$customerDao->expects($this->once())
 			->method('hasCustomerGotTimesheetItems')
 			->with(1)
@@ -140,7 +140,7 @@ class CustomerServiceTest extends PHPUnit_Framework_TestCase {
         
         $customers = array($customer1, $customer2);
         
-        $customerDao = $this->getMock('CustomerDao');
+        $customerDao = $this->getMockBuilder('CustomerDao')->getMock();
         $customerDao->expects($this->once())
             ->method('getCustomerNameList')
             ->with($allowdCustomers, true)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/EmploymentStatusServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/EmploymentStatusServiceTest.php
@@ -40,7 +40,7 @@ class EmploymentStatusServiceTest extends PHPUnit_Framework_TestCase {
 
 		$empStatusList = TestDataService::loadObjectList('EmploymentStatus', $this->fixture, 'EmploymentStatus');
 
-		$empStatusDao = $this->getMock('EmploymentStatusDao');
+		$empStatusDao = $this->getMockBuilder('EmploymentStatusDao')->getMock();
 		$empStatusDao->expects($this->once())
 			->method('getEmploymentStatusList')
 			->will($this->returnValue($empStatusList));
@@ -55,7 +55,7 @@ class EmploymentStatusServiceTest extends PHPUnit_Framework_TestCase {
 
 		$empStatusList = TestDataService::loadObjectList('EmploymentStatus', $this->fixture, 'EmploymentStatus');
 
-		$empStatusDao = $this->getMock('EmploymentStatusDao');
+		$empStatusDao = $this->getMockBuilder('EmploymentStatusDao')->getMock();
 		$empStatusDao->expects($this->once())
 			->method('getEmploymentStatusById')
 			->with(1)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/JobCategoryServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/JobCategoryServiceTest.php
@@ -40,7 +40,7 @@ class JobCategoryServiceTest extends PHPUnit_Framework_TestCase {
 
 		$jobCatList = TestDataService::loadObjectList('JobCategory', $this->fixture, 'JobCategory');
 
-		$jobCatDao = $this->getMock('JobCategoryDao');
+		$jobCatDao = $this->getMockBuilder('JobCategoryDao')->getMock();
 		$jobCatDao->expects($this->once())
 			->method('getJobCategoryList')
 			->will($this->returnValue($jobCatList));
@@ -55,7 +55,7 @@ class JobCategoryServiceTest extends PHPUnit_Framework_TestCase {
 
 		$jobCatList = TestDataService::loadObjectList('JobCategory', $this->fixture, 'JobCategory');
 
-		$jobCatDao = $this->getMock('JobCategoryDao');
+		$jobCatDao = $this->getMockBuilder('JobCategoryDao')->getMock();
 		$jobCatDao->expects($this->once())
 			->method('getJobCategoryById')
 			->with(1)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/JobTitleServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/JobTitleServiceTest.php
@@ -41,7 +41,7 @@ class JobTitleServiceTest extends PHPUnit_Framework_TestCase {
         
         $jobTitleList = TestDataService::loadObjectList('JobTitle', $this->fixture, 'JobTitle');
 
-        $jobTitleDao = $this->getMock('JobTitleDao');
+        $jobTitleDao = $this->getMockBuilder('JobTitleDao')->getMock();
 
         $jobTitleDao->expects($this->once())
                 ->method('getJobTitleList')
@@ -57,7 +57,7 @@ class JobTitleServiceTest extends PHPUnit_Framework_TestCase {
 
         $toBeDeletedJobTitleIds = array(1, 2);
 
-        $jobTitleDao = $this->getMock('JobTitleDao');
+        $jobTitleDao = $this->getMockBuilder('JobTitleDao')->getMock();
 
         $jobTitleDao->expects($this->once())
                 ->method('deleteJobTitle')
@@ -72,7 +72,7 @@ class JobTitleServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetJobTitleById() {
 
         $jobTitleList = TestDataService::loadObjectList('JobTitle', $this->fixture, 'JobTitle');
-        $jobTitleDao = $this->getMock('JobTitleDao');
+        $jobTitleDao = $this->getMockBuilder('JobTitleDao')->getMock();
 
         $jobTitleDao->expects($this->once())
                 ->method('getJobTitleById')

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/LocationServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/LocationServiceTest.php
@@ -41,7 +41,7 @@ class LocationServiceTest extends PHPUnit_Framework_TestCase {
 
 		$locationList = TestDataService::loadObjectList('Location', $this->fixture, 'Location');
 
-		$locationDao = $this->getMock('LocationDao');
+		$locationDao = $this->getMockBuilder('LocationDao')->getMock();
 		$locationDao->expects($this->once())
 			->method('getLocationById')
 			->with(1)
@@ -60,7 +60,7 @@ class LocationServiceTest extends PHPUnit_Framework_TestCase {
 		    'name' => 'location 1'
 		);
 		
-		$locationDao = $this->getMock('LocationDao');
+		$locationDao = $this->getMockBuilder('LocationDao')->getMock();
 		$locationDao->expects($this->once())
 			->method('searchLocations')
 			->with($srchClues)
@@ -79,7 +79,7 @@ class LocationServiceTest extends PHPUnit_Framework_TestCase {
 		    'name' => 'location 1'
 		);
 		
-		$locationDao = $this->getMock('LocationDao');
+		$locationDao = $this->getMockBuilder('LocationDao')->getMock();
 		$locationDao->expects($this->once())
 			->method('getSearchLocationListCount')
 			->with($srchClues)
@@ -95,7 +95,7 @@ class LocationServiceTest extends PHPUnit_Framework_TestCase {
 
 		$locationList = TestDataService::loadObjectList('Location', $this->fixture, 'Location');
 
-		$locationDao = $this->getMock('LocationDao');
+		$locationDao = $this->getMockBuilder('LocationDao')->getMock();
 		$locationDao->expects($this->once())
 			->method('getNumberOfEmplyeesForLocation')
 			->with(1)
@@ -111,7 +111,7 @@ class LocationServiceTest extends PHPUnit_Framework_TestCase {
 
 		$locationList = TestDataService::loadObjectList('Location', $this->fixture, 'Location');
 
-		$locationDao = $this->getMock('LocationDao');
+		$locationDao = $this->getMockBuilder('LocationDao')->getMock();
 		$locationDao->expects($this->once())
 			->method('getLocationList')
 			->will($this->returnValue($locationList));
@@ -127,7 +127,7 @@ class LocationServiceTest extends PHPUnit_Framework_TestCase {
 		$empNumbers = array(2, 34, 1, 20);
                 $locationIds = array(2, 3, 1);
 
-		$locationDao = $this->getMock('LocationDao');
+		$locationDao = $this->getMockBuilder('LocationDao')->getMock();
 		$locationDao->expects($this->once())
 			->method('getLocationIdsForEmployees')
                         ->with($empNumbers)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/MembershipServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/MembershipServiceTest.php
@@ -40,7 +40,7 @@ class MembershipServiceTest extends PHPUnit_Framework_TestCase {
 
         $membershipList = TestDataService::loadObjectList('Membership', $this->fixture, 'Membership');
 
-        $membershipDao = $this->getMock('MembershipDao');
+        $membershipDao = $this->getMockBuilder('MembershipDao')->getMock();
         $membershipDao->expects($this->once())
                 ->method('getMembershipList')
                 ->will($this->returnValue($membershipList));
@@ -55,7 +55,7 @@ class MembershipServiceTest extends PHPUnit_Framework_TestCase {
 
         $membershipList = TestDataService::loadObjectList('Membership', $this->fixture, 'Membership');
 
-        $membershipDao = $this->getMock('MembershipDao');
+        $membershipDao = $this->getMockBuilder('MembershipDao')->getMock();
         $membershipDao->expects($this->once())
                 ->method('getMembershipById')
                 ->with(1)
@@ -71,7 +71,7 @@ class MembershipServiceTest extends PHPUnit_Framework_TestCase {
 
         $membershipList = array(1, 2, 3);
 
-        $membershipDao = $this->getMock('MembershipDao');
+        $membershipDao = $this->getMockBuilder('MembershipDao')->getMock();
         $membershipDao->expects($this->once())
                 ->method('deleteMemberships')
                 ->with($membershipList)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/NationalityServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/NationalityServiceTest.php
@@ -40,7 +40,7 @@ class NationalityServiceTest extends PHPUnit_Framework_TestCase {
 
         $nationalityList = TestDataService::loadObjectList('Nationality', $this->fixture, 'Nationality');
 
-        $nationalityDao = $this->getMock('NationalityDao');
+        $nationalityDao = $this->getMockBuilder('NationalityDao')->getMock();
         $nationalityDao->expects($this->once())
                 ->method('getNationalityList')
                 ->will($this->returnValue($nationalityList));
@@ -55,7 +55,7 @@ class NationalityServiceTest extends PHPUnit_Framework_TestCase {
 
         $nationalityList = TestDataService::loadObjectList('Nationality', $this->fixture, 'Nationality');
 
-        $nationalityDao = $this->getMock('NationalityDao');
+        $nationalityDao = $this->getMockBuilder('NationalityDao')->getMock();
         $nationalityDao->expects($this->once())
                 ->method('getNationalityById')
                 ->with(1)
@@ -71,7 +71,7 @@ class NationalityServiceTest extends PHPUnit_Framework_TestCase {
 
         $nationalityList = array(1, 2, 3);
 
-        $nationalityDao = $this->getMock('NationalityDao');
+        $nationalityDao = $this->getMockBuilder('NationalityDao')->getMock();
         $nationalityDao->expects($this->once())
                 ->method('deleteNationalities')
                 ->with($nationalityList)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/OperationalCountryServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/OperationalCountryServiceTest.php
@@ -59,7 +59,9 @@ class OperationalCountryServiceTest extends PHPUnit_Framework_TestCase {
         $operationalCountryList[] = new OperationalCountry();
         $operationalCountryList[] = new OperationalCountry();
         
-        $operationalCountryDaoMock = $this->getMock('OperationalCountryDao', array('getOperationalCountryList'));
+        $operationalCountryDaoMock = $this->getMockBuilder('OperationalCountryDao')
+			->setMethods( array('getOperationalCountryList'))
+			->getMock();
         $operationalCountryDaoMock->expects($this->once())
                 ->method('getOperationalCountryList')
                 ->will($this->returnValue($operationalCountryList));
@@ -74,7 +76,9 @@ class OperationalCountryServiceTest extends PHPUnit_Framework_TestCase {
      * @expectedException ServiceException
      */
     public function testGetOperationalCountryList_WithException() {
-        $operationalCountryDaoMock = $this->getMock('OperationalCountryDao', array('getOperationalCountryList'));
+        $operationalCountryDaoMock = $this->getMockBuilder('OperationalCountryDao')
+			->setMethods( array('getOperationalCountryList'))
+			->getMock();
         $operationalCountryDaoMock->expects($this->once())
                 ->method('getOperationalCountryList')
                 ->will($this->throwException(new DaoException));
@@ -100,7 +104,9 @@ class OperationalCountryServiceTest extends PHPUnit_Framework_TestCase {
         $operationalCountry->setCountry($sriLanka);
         $operationalCountry->setCountryCode('LK');
         
-        $operationalCountryDaoMock = $this->getMock('OperationalCountryDao', array('getLocationsMappedToOperationalCountry'));
+        $operationalCountryDaoMock = $this->getMockBuilder('OperationalCountryDao')
+			->setMethods( array('getLocationsMappedToOperationalCountry'))
+			->getMock();
         $operationalCountryDaoMock->expects($this->once())
                 ->method('getLocationsMappedToOperationalCountry')
                 ->will($this->returnValue($locationList));
@@ -117,7 +123,9 @@ class OperationalCountryServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetLocationsMappedToOperationalCountry_WithException() {
         $operationalCountry = new OperationalCountry();
         
-        $operationalCountryDaoMock = $this->getMock('OperationalCountryDao', array('getLocationsMappedToOperationalCountry'));
+        $operationalCountryDaoMock = $this->getMockBuilder('OperationalCountryDao')
+			->setMethods( array('getLocationsMappedToOperationalCountry'))
+			->getMock();
         $operationalCountryDaoMock->expects($this->once())
                 ->method('getLocationsMappedToOperationalCountry')
                 ->will($this->throwException(new DaoException));
@@ -140,7 +148,9 @@ class OperationalCountryServiceTest extends PHPUnit_Framework_TestCase {
         $operationalCountryList[] = new OperationalCountry();
         $operationalCountryList[] = new OperationalCountry();
         
-        $operationalCountryDaoMock = $this->getMock('OperationalCountryDao', array('getOperationalCountriesForLocations'));
+        $operationalCountryDaoMock = $this->getMockBuilder('OperationalCountryDao')
+			->setMethods( array('getOperationalCountriesForLocations'))
+			->getMock();
         $operationalCountryDaoMock->expects($this->once())
                 ->method('getOperationalCountriesForLocations')
                 ->with($locationIdList)
@@ -158,7 +168,9 @@ class OperationalCountryServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetOperationalCountriesForLocations_WithException() {
         $operationalCountry = new OperationalCountry();
         
-        $operationalCountryDaoMock = $this->getMock('OperationalCountryDao', array('getOperationalCountriesForLocations'));
+        $operationalCountryDaoMock = $this->getMockBuilder('OperationalCountryDao')
+			->setMethods( array('getOperationalCountriesForLocations'))
+			->getMock();
         $operationalCountryDaoMock->expects($this->once())
                 ->method('getOperationalCountriesForLocations')
                 ->will($this->throwException(new DaoException));

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/PayGradeServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/PayGradeServiceTest.php
@@ -41,7 +41,7 @@ class PayGradeServiceTest extends PHPUnit_Framework_TestCase {
 
 		$payGradeList = TestDataService::loadObjectList('PayGrade', $this->fixture, 'PayGrade');
 
-		$payGradeDao = $this->getMock('PayGradeDao');
+		$payGradeDao = $this->getMockBuilder('PayGradeDao')->getMock();
 		$payGradeDao->expects($this->once())
 			->method('getPayGradeList')
 			->will($this->returnValue($payGradeList));
@@ -56,7 +56,7 @@ class PayGradeServiceTest extends PHPUnit_Framework_TestCase {
 
 		$payGradeList = TestDataService::loadObjectList('PayGrade', $this->fixture, 'PayGrade');
 
-		$payGradeDao = $this->getMock('PayGradeDao');
+		$payGradeDao = $this->getMockBuilder('PayGradeDao')->getMock();
 		$payGradeDao->expects($this->once())
 			->method('getPayGradeById')
 			->with(1)
@@ -73,7 +73,7 @@ class PayGradeServiceTest extends PHPUnit_Framework_TestCase {
 		$payGradeCurrencyList = TestDataService::loadObjectList('PayGradeCurrency', $this->fixture, 'PayGradeCurrency');
 		$payGradeCurrencyList = array($payGradeCurrencyList[0], $payGradeCurrencyList[1]);
 
-		$payGradeDao = $this->getMock('PayGradeDao');
+		$payGradeDao = $this->getMockBuilder('PayGradeDao')->getMock();
 		$payGradeDao->expects($this->once())
 			->method('getCurrencyListByPayGradeId')
 			->with(1)
@@ -89,7 +89,7 @@ class PayGradeServiceTest extends PHPUnit_Framework_TestCase {
 
 		$payGradeCurrencyList = TestDataService::loadObjectList('PayGradeCurrency', $this->fixture, 'PayGradeCurrency');
 
-		$payGradeDao = $this->getMock('PayGradeDao');
+		$payGradeDao = $this->getMockBuilder('PayGradeDao')->getMock();
 		$payGradeDao->expects($this->once())
 			->method('getCurrencyByCurrencyIdAndPayGradeId')
 			->with('USD', 1)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/ProjectServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/ProjectServiceTest.php
@@ -41,7 +41,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 		$projectList = TestDataService::loadObjectList('Project', $this->fixture, 'Project');
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getProjectCount')
 			->with(false)
@@ -55,7 +55,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteProject() {
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('deleteProject')
 			->with(1)
@@ -69,7 +69,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteProjectActivities() {
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('deleteProjectActivities')
 			->with(1)
@@ -85,7 +85,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 		$projectList = TestDataService::loadObjectList('Project', $this->fixture, 'Project');
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getProjectById')
 			->with(1)
@@ -101,7 +101,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 		$projectActivityList = TestDataService::loadObjectList('ProjectActivity', $this->fixture, 'ProjectActivity');
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getProjectActivityById')
 			->with(1)
@@ -117,7 +117,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 		$projectList = TestDataService::loadObjectList('Project', $this->fixture, 'Project');
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getAllProjects')
 			->with(false)
@@ -133,7 +133,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 		$projectActivityList = TestDataService::loadObjectList('ProjectActivity', $this->fixture, 'ProjectActivity');
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getActivityListByProjectId')
 			->with(1)
@@ -147,7 +147,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testHasActivityGotTimesheetItems() {
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('hasActivityGotTimesheetItems')
 			->with(1)
@@ -161,7 +161,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 
 	public function testHasProjectGotTimesheetItems() {
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('hasProjectGotTimesheetItems')
 			->with(1)
@@ -178,7 +178,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 		$projectList = TestDataService::loadObjectList('Project', $this->fixture, 'Project');
 		$projectList = array($projectList[0], $projectList[1]);
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getProjectsByCustomerId')
 			->with(1)
@@ -196,7 +196,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 		$empNumber = null;
 		$projectList = TestDataService::loadObjectList('Project', $this->fixture, 'Project');
 
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getProjectListForUserRole')
 			->with($role, $empNumber)
@@ -220,7 +220,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 		$projectList = TestDataService::loadObjectList('Project', $this->fixture, 'Project');
 		$projectList = array($projectList[0], $projectList[1]);
 		
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getActiveProjectList')
 			->will($this->returnValue($projectList));
@@ -238,7 +238,9 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 		
 		$projectId = array(1);
 		
-		$projectDao = $this->getMock('ProjectDao',array('getProjectAdminByEmpNumber', 'getProjectsByProjectIds'));
+		$projectDao = $this->getMockBuilder('ProjectDao')
+			->setMethods(array('getProjectAdminByEmpNumber', 'getProjectsByProjectIds'))
+			->getMock();
 		$projectDao->expects($this->once())
 			->method('getProjectAdminByEmpNumber')
 			->with(1)
@@ -269,7 +271,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 		);
 		$allowedProjectList = array(1);
 		
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('searchProjects')
 			->with($srchClues, $allowedProjectList)
@@ -289,7 +291,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
 		);
 		$allowedProjectList = array(1);
 		
-		$projectDao = $this->getMock('ProjectDao');
+		$projectDao = $this->getMockBuilder('ProjectDao')->getMock();
 		$projectDao->expects($this->once())
 			->method('getSearchProjectListCount')
 			->with($srchClues, $allowedProjectList)
@@ -306,7 +308,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
             $project = new Project();
             $expected = array($project);
 
-            $projectDao = $this->getMock('ProjectDao');
+            $projectDao = $this->getMockBuilder('ProjectDao')->getMock();
             $projectDao->expects($this->once())
                     ->method('getActiveProjectsOrderedByCustomer')
                     ->will($this->returnValue($expected));
@@ -322,7 +324,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
         $projectIdList = array(1, 2);
         $customerIds = array(1, 4);
         
-        $projectDao = $this->getMock('ProjectDao');
+        $projectDao = $this->getMockBuilder('ProjectDao')->getMock();
         $projectDao->expects($this->once())
                 ->method('getCustomerIdListByProjectId')
                 ->with($projectIdList)
@@ -346,7 +348,7 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
         
         $projects = array($project1, $project1);
         
-        $projectDao = $this->getMock('ProjectDao');
+        $projectDao = $this->getMockBuilder('ProjectDao')->getMock();
         $projectDao->expects($this->once())
                 ->method('getProjectNameList')
                 ->with($projectIdList, true)
@@ -362,7 +364,9 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetProjectActivityCount() {
         $count = 34;
         
-        $projectDao = $this->getMock('ProjectDao', array('getProjectActivityCount'));
+        $projectDao = $this->getMockBuilder('ProjectDao')
+			->setMethods( array('getProjectActivityCount'))
+			->getMock();
         $projectDao->expects($this->once())
                 ->method('getProjectActivityCount')
                 ->with()
@@ -377,7 +381,9 @@ class ProjectServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetProjectActivityCountWithDeleted() {
         $count = 44;
         
-        $projectDao = $this->getMock('ProjectDao', array('getProjectActivityCount'));
+        $projectDao = $this->getMockBuilder('ProjectDao')
+			->setMethods( array('getProjectActivityCount'))
+			->getMock();
         $projectDao->expects($this->once())
                 ->method('getProjectActivityCount')
                 ->with(true)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/SystemUserServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/SystemUserServiceTest.php
@@ -49,7 +49,7 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
             $userRoles->add($userRole);
         }
         
-        $dao = $this->getMock('SystemUserDao');
+        $dao = $this->getMockBuilder('SystemUserDao')->getMock();
         
         $dao->expects($this->once())
              ->method('getNonPredefinedUserRoles')
@@ -71,7 +71,7 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserName('admin_user');
         $user->setUserPassword($password);                
         
-        $dao = $this->getMock('SystemUserDao');
+        $dao = $this->getMockBuilder('SystemUserDao')->getMock();
         
         $dao->expects($this->once())
              ->method('saveSystemUser')
@@ -92,7 +92,7 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserName('admin_user');
         $user->setUserPassword($password);
 
-        $dao = $this->getMock('SystemUserDao');
+        $dao = $this->getMockBuilder('SystemUserDao')->getMock();
 
         $dao->expects($this->once())
                 ->method('saveSystemUser')
@@ -116,7 +116,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $userId = 5;
         $password = 'sadffas';
         
-        $dao = $this->getMock('SystemUserDao', array('getSystemUser'));
+        $dao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('getSystemUser'))
+			->getMock();
 
         $dao->expects($this->once())
                 ->method('getSystemUser')
@@ -142,7 +144,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserPassword($hashedPassword);
 
         
-        $dao = $this->getMock('SystemUserDao', array('getSystemUser'));
+        $dao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('getSystemUser'))
+			->getMock();
 
         $dao->expects($this->once())
                 ->method('getSystemUser')
@@ -167,7 +171,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserPassword($hashedPassword);
 
         
-        $dao = $this->getMock('SystemUserDao', array('getSystemUser'));
+        $dao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('getSystemUser'))
+			->getMock();
 
         $dao->expects($this->once())
                 ->method('getSystemUser')
@@ -192,7 +198,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserPassword($hashedPassword);
 
         
-        $dao = $this->getMock('SystemUserDao', array('getSystemUser'));
+        $dao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('getSystemUser'))
+			->getMock();
 
         $dao->expects($this->once())
                 ->method('getSystemUser')
@@ -218,7 +226,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
                 ->with($password)
                 ->will($this->returnValue($hashedPassword));
         
-        $mockDao = $this->getMock('SystemUserDao', array('updatePassword'));
+        $mockDao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('updatePassword'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('updatePassword')
                 ->with($userId, $hashedPassword)
@@ -236,7 +246,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $userName = 'adminUser1';
         $password = 'isd#@!';
         
-        $mockDao = $this->getMock('SystemUserDao', array('isExistingSystemUser'));
+        $mockDao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('isExistingSystemUser'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('isExistingSystemUser')
                 ->with($userName)
@@ -269,7 +281,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
                 ->with($password, $hashedPassword)
                 ->will($this->returnValue(true));        
         
-        $mockDao = $this->getMock('SystemUserDao', array('isExistingSystemUser'));
+        $mockDao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('isExistingSystemUser'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('isExistingSystemUser')
                 ->with($userName)
@@ -297,7 +311,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserPassword($hashedPassword);        
       
         
-        $mockDao = $this->getMock('SystemUserDao', array('isExistingSystemUser', 'saveSystemUser'));
+        $mockDao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('isExistingSystemUser', 'saveSystemUser'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('isExistingSystemUser')
                 ->with($userName)
@@ -331,7 +347,9 @@ class SystemUserServiceTest extends PHPUnit_Framework_TestCase {
         $user->setUserPassword($hashedPassword);        
       
         
-        $mockDao = $this->getMock('SystemUserDao', array('isExistingSystemUser'));
+        $mockDao = $this->getMockBuilder('SystemUserDao')
+			->setMethods( array('isExistingSystemUser'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('isExistingSystemUser')
                 ->with($userName)

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/service/WorkShiftServiceTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/service/WorkShiftServiceTest.php
@@ -40,7 +40,7 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
 
         $workShiftList = TestDataService::loadObjectList('WorkShift', $this->fixture, 'WorkShift');
 
-        $workShiftDao = $this->getMock('WorkShiftDao');
+        $workShiftDao = $this->getMockBuilder('WorkShiftDao')->getMock();
         $workShiftDao->expects($this->once())
                 ->method('getWorkShiftList')
                 ->will($this->returnValue($workShiftList));
@@ -55,7 +55,7 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
 
         $workShiftList = TestDataService::loadObjectList('WorkShift', $this->fixture, 'WorkShift');
 
-        $workShiftDao = $this->getMock('WorkShiftDao');
+        $workShiftDao = $this->getMockBuilder('WorkShiftDao')->getMock();
         $workShiftDao->expects($this->once())
                 ->method('getWorkShiftById')
                 ->with(1)
@@ -71,7 +71,7 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
 
         $workShiftList = TestDataService::loadObjectList('EmployeeWorkShift', $this->fixture, 'EmployeeWorkShift');
 
-        $workShiftDao = $this->getMock('WorkShiftDao');
+        $workShiftDao = $this->getMockBuilder('WorkShiftDao')->getMock();
         $workShiftDao->expects($this->once())
                 ->method('getWorkShiftEmployeeListById')
                 ->with(1)
@@ -87,7 +87,7 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
 
         $workShiftList = TestDataService::loadObjectList('EmployeeWorkShift', $this->fixture, 'EmployeeWorkShift');
 
-        $workShiftDao = $this->getMock('WorkShiftDao');
+        $workShiftDao = $this->getMockBuilder('WorkShiftDao')->getMock();
         $workShiftDao->expects($this->once())
                 ->method('getWorkShiftEmployeeList')
                 ->will($this->returnValue($workShiftList));
@@ -102,7 +102,7 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
 
         $workShiftList = TestDataService::loadObjectList('WorkShift', $this->fixture, 'WorkShift');
 
-        $workShiftDao = $this->getMock('WorkShiftDao');
+        $workShiftDao = $this->getMockBuilder('WorkShiftDao')->getMock();
         $workShiftDao->expects($this->once())
                 ->method('updateWorkShift')
                 ->with($workShiftList[0])
@@ -118,7 +118,9 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
         $startTime = '07:23';
         $endTime = '19:00';
 
-        $configService = $this->getMock('ConfigService', array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'));
+        $configService = $this->getMockBuilder('ConfigService')
+			->setMethods( array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'))
+			->getMock();
         $configService->expects($this->once())
                 ->method('getDefaultWorkShiftStartTime')
                 ->will($this->returnValue($startTime));
@@ -136,7 +138,9 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetWorkShiftDefaultStartAndEndTimeWhenNoDefaultConfigured() {
-        $configService = $this->getMock('ConfigService', array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'));
+        $configService = $this->getMockBuilder('ConfigService')
+			->setMethods( array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'))
+			->getMock();
         $configService->expects($this->once())
                 ->method('getDefaultWorkShiftStartTime')
                 ->will($this->returnValue(null));
@@ -154,7 +158,9 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetWorkShiftDefaultStartAndEndTimeWithInvalidDefaultStartTime() {
-        $configService = $this->getMock('ConfigService', array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'));
+        $configService = $this->getMockBuilder('ConfigService')
+			->setMethods( array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'))
+			->getMock();
         $configService->expects($this->once())
                 ->method('getDefaultWorkShiftStartTime')
                 ->will($this->returnValue('II:00'));
@@ -172,7 +178,9 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetWorkShiftDefaultStartAndEndTimeWithInvalidDefaultEndTime() {
-        $configService = $this->getMock('ConfigService', array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'));
+        $configService = $this->getMockBuilder('ConfigService')
+			->setMethods( array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'))
+			->getMock();
         $configService->expects($this->once())
                 ->method('getDefaultWorkShiftStartTime')
                 ->will($this->returnValue('08:00'));
@@ -190,7 +198,9 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetWorkShiftDefaultStartAndEndTimeWhenDefaultDurationNegative() {
-        $configService = $this->getMock('ConfigService', array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'));
+        $configService = $this->getMockBuilder('ConfigService')
+			->setMethods( array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'))
+			->getMock();
         $configService->expects($this->once())
                 ->method('getDefaultWorkShiftStartTime')
                 ->will($this->returnValue('17:00'));
@@ -211,7 +221,9 @@ class WorkShiftServiceTest extends PHPUnit_Framework_TestCase {
         $startTime = '07:23';
         $endTime = '07:50';
 
-        $configService = $this->getMock('ConfigService', array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'));
+        $configService = $this->getMockBuilder('ConfigService')
+			->setMethods( array('getDefaultWorkShiftStartTime', 'getDefaultWorkShiftEndTime'))
+			->getMock();
         $configService->expects($this->once())
                 ->method('getDefaultWorkShiftStartTime')
                 ->will($this->returnValue($startTime));

--- a/symfony/plugins/orangehrmAdminPlugin/test/model/wrapper/AdminWebServiceWrapperTest.php
+++ b/symfony/plugins/orangehrmAdminPlugin/test/model/wrapper/AdminWebServiceWrapperTest.php
@@ -76,7 +76,7 @@ class AdminWebServiceWrapperTest extends PHPUnit_Framework_TestCase {
         $paramObj->setSessionToken(uniqid('ohrm_ws_session_'));
         $paramObj->setParameters(array(0));
         $paramObj->setRequestMethod('GET');
-        $mock = $this->getMock('AdminWebServiceHelper', array('getAccessibleLocations'));
+        $mock = $this->getMockBuilder('AdminWebServiceHelper')->setMethods(array('getAccessibleLocations'))->getMock();
         $mock->method('getAccessibleLocations')
                 ->will($this->returnValue(array()));
 

--- a/symfony/plugins/orangehrmAttendancePlugin/test/model/service/AttendanceServiceTest.php
+++ b/symfony/plugins/orangehrmAttendancePlugin/test/model/service/AttendanceServiceTest.php
@@ -42,7 +42,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $attendanceRecords = TestDataService::loadObjectList('AttendanceRecord', $this->fixture, 'AttendanceRecord');
         $attendanceRecord = $attendanceRecords[0];
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('savePunchRecord'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('savePunchRecord'))
+			->getMock();
 
         $attendanceDaoMock->expects($this->once())
                 ->method('savePunchRecord')
@@ -62,7 +64,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $actionableStateList = array(AttendanceRecord::STATE_PUNCHED_IN);
 
         $lastPunchRecord = TestDataService::fetchObject('AttendanceRecord', 2);
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('getLastPunchRecord'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('getLastPunchRecord'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('getLastPunchRecord')
                 ->with($employeeId, $actionableStateList)
@@ -85,7 +89,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $action = "EDIT";
         $resultingState = "CREATED";
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('getSavedConfiguration'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('getSavedConfiguration'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('getSavedConfiguration')
                 ->with($workflow, $state, $role, $action, $resultingState)
@@ -107,7 +113,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $isValid = "0";
         $recordId = 121;
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('checkForPunchOutOverLappingRecords'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('checkForPunchOutOverLappingRecords'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('checkForPunchOutOverLappingRecords')
                 ->with($punchInTime, $punchOutTime, $employeeId, $recordId)
@@ -127,7 +135,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $employeeId = "5";
         $isValid = "0";
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('checkForPunchInOverLappingRecords'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('checkForPunchInOverLappingRecords'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('checkForPunchInOverLappingRecords')
                 ->with($punchInTime, $employeeId)
@@ -148,7 +158,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $employeeId = 5;
 
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('getAttendanceRecord'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('getAttendanceRecord'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('getAttendanceRecord')
                 ->with($employeeId, $date)
@@ -166,7 +178,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $attendanceRecordId = 4;
         $isDeleted = true;
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('deleteAttendanceRecords'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('deleteAttendanceRecords'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('deleteAttendanceRecords')
                 ->with($attendanceRecordId)
@@ -179,7 +193,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $attendanceRecordId = 12344;
         $isDeleted = false;
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('deleteAttendanceRecords'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('deleteAttendanceRecords'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('deleteAttendanceRecords')
                 ->with($attendanceRecordId)
@@ -198,7 +214,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
         $attendanceRecordId = 4;
         $attendanceRecord = TestDataService::fetchObject('AttendanceRecord', $attendanceRecordId);
 
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('getAttendanceRecordById'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('getAttendanceRecordById'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('getAttendanceRecordById')
                 ->with($attendanceRecordId)
@@ -274,7 +292,9 @@ class AttendanceServiceTest extends PHPUnit_Framework_Testcase {
      * @group orangehrmAttendancePlugin
      */
     public function testSearchAttendanceRecords() {
-        $attendanceDaoMock = $this->getMock('AttendanceDao', array('searchAttendanceRecords'));
+        $attendanceDaoMock = $this->getMockBuilder('AttendanceDao')
+			->setMethods( array('searchAttendanceRecords'))
+			->getMock();
         $attendanceDaoMock->expects($this->once())
                 ->method('searchAttendanceRecords')
                 ->with($attendanceRecordId)

--- a/symfony/plugins/orangehrmBeaconPlugin/test/model/service/BeaconCommunicationServiceTest.php
+++ b/symfony/plugins/orangehrmBeaconPlugin/test/model/service/BeaconCommunicationServiceTest.php
@@ -20,7 +20,7 @@ class BeaconCommunicationServiceTest extends PHPUnit_Framework_TestCase {
     public function setUp() {
         $this->beaconCommunicationService = new BeaconCommunicationsService();
         $this->fixture = sfConfig::get('sf_plugins_dir') . '/orangehrmBeaconPlugin/test/fixtures/BeaconDatapointService.yml';
-        $this->beaconConfigService = $this->getMock('BeaconConfigService', array('setBeaconLock', 'getBeaconLock', 'getBeaconActivationAcceptanceStatus', 'getBeaconActivationStatus', 'getBeaconNextFlashTime', 'changeConfigTable', 'resolveNotificationMessages'));
+        $this->beaconConfigService = $this->getMockBuilder('BeaconConfigService')->setMethods(array('setBeaconLock', 'getBeaconLock', 'getBeaconActivationAcceptanceStatus', 'getBeaconActivationStatus', 'getBeaconNextFlashTime', 'changeConfigTable', 'resolveNotificationMessages'))->getMock();
     }
 
     public function testCheckFlashTimeExpiry() {

--- a/symfony/plugins/orangehrmBeaconPlugin/test/model/service/BeaconConfigurationServiceTest.php
+++ b/symfony/plugins/orangehrmBeaconPlugin/test/model/service/BeaconConfigurationServiceTest.php
@@ -43,7 +43,9 @@ class BeaconConfigurationServiceTest extends PHPUnit_Framework_TestCase{
 //        <value>604800</value>
 //    </change>'
     );
-        $configDao = $this->getMock('ConfigDao',  array('setValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')
+			->setMethods(  array('setValue'))
+			->getMock();
         $configDao->expects($this->exactly(1))
                 ->method('setValue')
                 ->with($this->stringContains('beacon.flash_period'),  $this->equalTo('604800'));

--- a/symfony/plugins/orangehrmBeaconPlugin/test/model/service/BeaconDatapointServiceTest.php
+++ b/symfony/plugins/orangehrmBeaconPlugin/test/model/service/BeaconDatapointServiceTest.php
@@ -25,7 +25,9 @@ class BeaconDatapointServiceTest extends PHPUnit_Framework_TestCase {
 
         $datapointList = TestDataService::loadObjectList('DataPoint', $this->fixture, 'set1');
 
-        $beaconDatapointDao = $this->getMock('BeaconDatapointDao', array('getAllDatapoints'));
+        $beaconDatapointDao = $this->getMockBuilder('BeaconDatapointDao')
+			->setMethods( array('getAllDatapoints'))
+			->getMock();
         $beaconDatapointDao->expects($this->once())
                 ->method('getAllDatapoints')
                 ->will($this->returnValue($datapointList));
@@ -43,7 +45,9 @@ class BeaconDatapointServiceTest extends PHPUnit_Framework_TestCase {
         $tableName = 'hs_hr_employee';
         $tableNames = array('hs_hr_employee','ohrm_oauth_refresh_token','ohrm_nationality','ohrm_pay_grade');
         
-         $beaconDatapointDao = $this->getMock('BeaconDatapointDao', array('getTableNames'));
+         $beaconDatapointDao = $this->getMockBuilder('BeaconDatapointDao')
+			->setMethods( array('getTableNames'))
+			->getMock();
         $beaconDatapointDao->expects($this->once())
                 ->method('getTableNames')
                 ->will($this->returnValue($tableNames));

--- a/symfony/plugins/orangehrmBeaconPlugin/test/processor/CountDataPointProcessorTest.php
+++ b/symfony/plugins/orangehrmBeaconPlugin/test/processor/CountDataPointProcessorTest.php
@@ -21,7 +21,9 @@ class CountDataPointProcessorTest extends PHPUnit_Framework_TestCase {
 
     public function testProcessCountDatapoint() {
 
-        $countDatapointProcessor = $this->getMock('countDataPointProcessor', array('executeQuery', 'sanitize'));
+        $countDatapointProcessor = $this->getMockBuilder('countDataPointProcessor')
+			->setMethods( array('executeQuery', 'sanitize'))
+			->getMock();
 
         $countDatapointProcessor->expects($this->any())
                 ->method('executeQuery')

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/manager/BasicUserRoleManagerTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/manager/BasicUserRoleManagerTest.php
@@ -646,7 +646,9 @@ class BasicUserRoleManagerTest extends PHPUnit_Framework_TestCase {
         $this->manager->setSystemUserService($systemUserService);
         $this->manager->setUser($user);       
         
-        $mockScreenPermissionService = $this->getMock('ScreenPermissionService', array('getScreenPermissions'));
+        $mockScreenPermissionService = $this->getMockBuilder('ScreenPermissionService')
+			->setMethods( array('getScreenPermissions'))
+			->getMock();
         $permission = new ResourcePermission(true, false, true, false);
         
         $module = 'admin';
@@ -822,7 +824,9 @@ class BasicUserRoleManagerTest extends PHPUnit_Framework_TestCase {
         
         $employeeIds = array(1, 2, 3);
         
-        $employeeService = $this->getMock('EmployeeService', array('getSubordinateIdListBySupervisorId'));
+        $employeeService = $this->getMockBuilder('EmployeeService')
+			->setMethods( array('getSubordinateIdListBySupervisorId'))
+			->getMock();
         $employeeService->expects($this->once())
                  ->method('getSubordinateIdListBySupervisorId')
                 ->with($user->getEmpNumber())
@@ -865,7 +869,9 @@ class BasicUserRoleManagerTest extends PHPUnit_Framework_TestCase {
         $homePages = array(
             $homePage1, $homePage2, $homePage3, $homePage4, $homePage5
         );
-        $mockDao = $this->getMock('HomePageDao', array('getHomePagesInPriorityOrder'));
+        $mockDao = $this->getMockBuilder('HomePageDao')
+			->setMethods( array('getHomePagesInPriorityOrder'))
+			->getMock();
         $mockDao->expects($this->once())
                  ->method('getHomePagesInPriorityOrder')
                 ->with($userRoleIds)
@@ -906,7 +912,9 @@ class BasicUserRoleManagerTest extends PHPUnit_Framework_TestCase {
         $defaultPages = array(
             $defaultPage1, $defaultPage2, $defaultPage3, $defaultPage4, $defaultPage5
         );
-        $mockDao = $this->getMock('HomePageDao', array('getModuleDefaultPagesInPriorityOrder'));
+        $mockDao = $this->getMockBuilder('HomePageDao')
+			->setMethods( array('getModuleDefaultPagesInPriorityOrder'))
+			->getMock();
         $mockDao->expects($this->once())
                  ->method('getModuleDefaultPagesInPriorityOrder')
                 ->with($module, $userRoleIds)

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/manager/BasicUserRoleManagerTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/manager/BasicUserRoleManagerTest.php
@@ -636,7 +636,7 @@ class BasicUserRoleManagerTest extends PHPUnit_Framework_TestCase {
         $user->setEmpNumber(NULL);
         $user->setUserRole($userRole);
         
-        $systemUserService = $this->getMock('SystemUserService', array('getSystemUser'));
+        $systemUserService = $this->getMockBuilder('SystemUserService')->setMethods(array('getSystemUser'))->getMock();
         
         $systemUserService->expects($this->once())
                 ->method('getSystemUser')
@@ -814,7 +814,7 @@ class BasicUserRoleManagerTest extends PHPUnit_Framework_TestCase {
         $user->setEmpNumber(9);
         
         
-        $systemUserService = $this->getMock('SystemUserService', array('getSystemUser'));
+        $systemUserService = $this->getMockBuilder('SystemUserService')->setMethods(array('getSystemUser'))->getMock();
         $systemUserService->expects($this->once())
                  ->method('getSystemUser')
                  ->will($this->returnValue($user));

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/service/DataGroupServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/service/DataGroupServiceTest.php
@@ -39,7 +39,9 @@ class DataGroupServiceTest extends PHPUnit_Framework_TestCase {
         $dataGroupPermission->fromArray(array('id' => 2, 'user_role_id' => 1, 'data_group_id' => 1,
             'can_read' => 1, 'can_create' => 1, 'can_update' => 1, 'can_delete' => 1, 'self' => 1));
 
-        $dao = $this->getMock('DataGroupDao', array('getDataGroupPermission'));
+        $dao = $this->getMockBuilder('DataGroupDao')
+			->setMethods( array('getDataGroupPermission'))
+			->getMock();
         $dao->expects($this->once())
                     ->method('getDataGroupPermission')
                     ->with('test', 2, true)
@@ -54,7 +56,9 @@ class DataGroupServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetDataGroups() {
         $expected = new Doctrine_Collection('DataGroup');        
 
-        $dao = $this->getMock('DataGroupDao', array('getDataGroups'));
+        $dao = $this->getMockBuilder('DataGroupDao')
+			->setMethods( array('getDataGroups'))
+			->getMock();
         $dao->expects($this->once())
                     ->method('getDataGroups')
                     ->will($this->returnValue($expected));
@@ -68,7 +72,9 @@ class DataGroupServiceTest extends PHPUnit_Framework_TestCase {
         $expected = new DataGroup();
         $expected->fromArray(array('id' => 2, 'can_read' => 1, 'can_create' => 1, 'can_update' => 1, 'can_delete' => 1));
 
-        $dao = $this->getMock('DataGroupDao', array('getDataGroup'));
+        $dao = $this->getMockBuilder('DataGroupDao')
+			->setMethods( array('getDataGroup'))
+			->getMock();
         $dao->expects($this->once())
                     ->method('getDataGroup')
                     ->with('xyz')

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/service/ScreenPermissionServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/service/ScreenPermissionServiceTest.php
@@ -44,7 +44,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $action = 'doThis';
         $roles = '';
         
-        $permissionDao = $this->getMock('ScreenPermissionDao', array('getScreenPermissions'));
+        $permissionDao = $this->getMockBuilder('ScreenPermissionDao')
+			->setMethods( array('getScreenPermissions'))
+			->getMock();
         $emptyDoctrineCollection = new Doctrine_Collection('ScreenPermission');
         
         $permissionDao->expects($this->once())
@@ -54,7 +56,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         
         $this->service->setScreenPermissionDao($permissionDao);
         
-        $screenDao = $this->getMock('ScreenDao', array('getScreen'));
+        $screenDao = $this->getMockBuilder('ScreenDao')
+			->setMethods( array('getScreen'))
+			->getMock();
         $screenDao->expects($this->once())
                 ->method('getScreen')
                 ->with($module, $action)
@@ -74,7 +78,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $action = 'doThis';
         $roles = '';
         
-        $mockDao = $this->getMock('ScreenPermissionDao', array('getScreenPermissions'));
+        $mockDao = $this->getMockBuilder('ScreenPermissionDao')
+			->setMethods( array('getScreenPermissions'))
+			->getMock();
         $emptyDoctrineCollection = new Doctrine_Collection('ScreenPermission');
         
         $mockDao->expects($this->once())
@@ -87,7 +93,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $screen = new Screen();
         $screen->setName('abc');
         
-        $screenDao = $this->getMock('ScreenDao', array('getScreen'));
+        $screenDao = $this->getMockBuilder('ScreenDao')
+			->setMethods( array('getScreen'))
+			->getMock();
         $screenDao->expects($this->once())
                 ->method('getScreen')
                 ->with($module, $action)
@@ -121,7 +129,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $screenPermissions = array($screenPermission1, $screenPermission2);
         $doctrineCollection->setData($screenPermissions);
         
-        $mockDao = $this->getMock('ScreenPermissionDao', array('getScreenPermissions'));        
+        $mockDao = $this->getMockBuilder('ScreenPermissionDao')
+			->setMethods( array('getScreenPermissions'))
+			->getMock();        
         $mockDao->expects($this->once())
                 ->method('getScreenPermissions')
                 ->with($module, $action, $roles)
@@ -154,7 +164,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $screenPermissions = array($screenPermission1, $screenPermission2);
         $doctrineCollection->setData($screenPermissions);
         
-        $mockDao = $this->getMock('ScreenPermissionDao', array('getScreenPermissions'));        
+        $mockDao = $this->getMockBuilder('ScreenPermissionDao')
+			->setMethods( array('getScreenPermissions'))
+			->getMock();        
         $mockDao->expects($this->once())
                 ->method('getScreenPermissions')
                 ->with($module, $action, $roles)
@@ -192,7 +204,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $screenPermissions = array($screenPermission1, $screenPermission2, $screenPermission3);
         $doctrineCollection->setData($screenPermissions);
         
-        $mockDao = $this->getMock('ScreenPermissionDao', array('getScreenPermissions'));        
+        $mockDao = $this->getMockBuilder('ScreenPermissionDao')
+			->setMethods( array('getScreenPermissions'))
+			->getMock();        
         $mockDao->expects($this->once())
                 ->method('getScreenPermissions')
                 ->with($module, $action, $roles)
@@ -217,7 +231,9 @@ class ScreenPermissionServiceTest extends PHPUnit_Framework_TestCase {
         $expected->setActionUrl($action);
 
     
-        $screenDao = $this->getMock('ScreenDao', array('getScreen'));
+        $screenDao = $this->getMockBuilder('ScreenDao')
+			->setMethods( array('getScreen'))
+			->getMock();
         $screenDao->expects($this->once())
                 ->method('getScreen')
                 ->with($module, $action)

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/service/UserRoleManagerServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/service/UserRoleManagerServiceTest.php
@@ -39,7 +39,9 @@ class UserRoleManagerServiceTest extends PHPUnit_Framework_TestCase {
      * Test the getConfigDao() and setConfigDao() method
      */
     public function testGetUserRoleManagerClassName() {
-        $configDao = $this->getMock('ConfigDao', array('getValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $configDao->expects($this->once())
                 ->method('getValue')
                 ->with(UserRoleManagerService::KEY_USER_ROLE_MANAGER_CLASS)
@@ -51,13 +53,17 @@ class UserRoleManagerServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testGetUserRoleManagerExistingClass() {
-        $configDao = $this->getMock('ConfigDao', array('getValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $configDao->expects($this->once())
                 ->method('getValue')
                 ->with(UserRoleManagerService::KEY_USER_ROLE_MANAGER_CLASS)
                 ->will($this->returnValue('UnitTestUserRoleManager'));
         
-        $authenticationService = $this->getMock('AuthenticationService', array('getLoggedInUserId'));
+        $authenticationService = $this->getMockBuilder('AuthenticationService')
+			->setMethods( array('getLoggedInUserId'))
+			->getMock();
         $authenticationService->expects($this->once())
                               ->method('getLoggedInUserId')
                               ->will($this->returnValue(211));
@@ -65,7 +71,9 @@ class UserRoleManagerServiceTest extends PHPUnit_Framework_TestCase {
         $systemUser = new SystemUser();
         $systemUser->setId(211);
         
-        $systemUserService = $this->getMock('SystemUserService', array('getSystemUser'));
+        $systemUserService = $this->getMockBuilder('SystemUserService')
+			->setMethods( array('getSystemUser'))
+			->getMock();
         $systemUserService->expects($this->once())
                           ->method('getSystemUser')
                           ->will($this->returnValue($systemUser));
@@ -83,7 +91,9 @@ class UserRoleManagerServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testGetUserRoleManagerInvalidClass() {
-        $configDao = $this->getMock('ConfigDao', array('getValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $configDao->expects($this->once())
                 ->method('getValue')
                 ->with(UserRoleManagerService::KEY_USER_ROLE_MANAGER_CLASS)
@@ -117,20 +127,26 @@ class UserRoleManagerServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testGetUserRoleManagerNoLoggedInUser() {
-        $configDao = $this->getMock('ConfigDao', array('getValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $configDao->expects($this->once())
                 ->method('getValue')
                 ->with(UserRoleManagerService::KEY_USER_ROLE_MANAGER_CLASS)
                 ->will($this->returnValue('UnitTestUserRoleManager'));
         
 
-        $authenticationService = $this->getMock('AuthenticationService', array('getLoggedInUserId'));
+        $authenticationService = $this->getMockBuilder('AuthenticationService')
+			->setMethods( array('getLoggedInUserId'))
+			->getMock();
         $authenticationService->expects($this->once())
                               ->method('getLoggedInUserId')
                               ->will($this->returnValue(NULL));
         
         
-        $systemUserService = $this->getMock('SystemUserService', array('getSystemUser'));
+        $systemUserService = $this->getMockBuilder('SystemUserService')
+			->setMethods( array('getSystemUser'))
+			->getMock();
         $systemUserService->expects($this->once())
                           ->method('getSystemUser')
                           ->with(NULL)

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/service/UserRoleManagerServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/service/UserRoleManagerServiceTest.php
@@ -110,7 +110,7 @@ class UserRoleManagerServiceTest extends PHPUnit_Framework_TestCase {
     } 
     
     public function testGetUserRoleManagerNonExistingClass() {
-        $configDao = $this->getMock('ConfigDao', array('getValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')->setMethods(array('getValue'))->getMock();
         $configDao->expects($this->once())
                 ->method('getValue')
                 ->with(UserRoleManagerService::KEY_USER_ROLE_MANAGER_CLASS)

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/userrole/AdminUserRoleTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/userrole/AdminUserRoleTest.php
@@ -39,35 +39,35 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetSetEmployeeService() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
 
         $this->adminUserRole->setEmployeeService($mockService);
         $this->assertEquals($mockService, $this->adminUserRole->getEmployeeService());
     }
 
     public function testGetSetSystemUserService() {
-        $mockService = $this->getMock('SystemUserService');
+        $mockService = $this->getMockBuilder('SystemUserService')->getMock();
 
         $this->adminUserRole->setSystemUserService($mockService);
         $this->assertEquals($mockService, $this->adminUserRole->getSystemUserService());
     }
 
     public function testGetSetLocationService() {
-        $mockService = $this->getMock('LocationService');
+        $mockService = $this->getMockBuilder('LocationService')->getMock();
 
         $this->adminUserRole->setLocationService($mockService);
         $this->assertEquals($mockService, $this->adminUserRole->getLocationService());
     }
 
     public function testGetSetOperationalCountryService() {
-        $mockService = $this->getMock('OperationalCountryService');
+        $mockService = $this->getMockBuilder('OperationalCountryService')->getMock();
 
         $this->adminUserRole->setOperationalCountryService($mockService);
         $this->assertEquals($mockService, $this->adminUserRole->getOperationalCountryService());
     }
 
     public function testGetAccessibleEmployeeIds() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
         $mockService->expects($this->once())
                 ->method('getEmployeeIdList')
                 ->with(false)
@@ -79,7 +79,7 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleEmployeePropertyList() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
         $properties = array("empNumber", "firstName", "middleName", "lastName", "termination_id");
         $propertyList = new Doctrine_Collection('Employee');
         for ($i = 0; $i < 2; $i++) {
@@ -100,7 +100,7 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleEmployees() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
         $employeeList = new Doctrine_Collection('Employee');
         for ($i = 0; $i < 2; $i++) {
             $employee = new Employee();
@@ -124,7 +124,7 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleLocationIds() {
-        $mockService = $this->getMock('LocationService');
+        $mockService = $this->getMockBuilder('LocationService')->getMock();
         $locationList = new Doctrine_Collection('Location');
         for ($i = 0; $i < 3; $i++) {
             $location = new Location();
@@ -142,7 +142,7 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleOperationalCountryIds() {
-        $mockService = $this->getMock('OperationalCountryService');
+        $mockService = $this->getMockBuilder('OperationalCountryService')->getMock();
         $opCountryList = new Doctrine_Collection('OperationalCountry');
         for ($i = 0; $i < 3; $i++) {
             $operationalCountry = new OperationalCountry();
@@ -160,7 +160,7 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleSystemUserIds() {
-        $mockService = $this->getMock('SystemUserService');
+        $mockService = $this->getMockBuilder('SystemUserService')->getMock();
 
         $mockService->expects($this->once())
                 ->method('getSystemUserIdList')
@@ -172,7 +172,7 @@ class AdminUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleUserRoleIds() {
-        $mockService = $this->getMock('SystemUserService');
+        $mockService = $this->getMockBuilder('SystemUserService')->getMock();
         $roleList = new Doctrine_Collection('SystemUser');
         for ($i = 0; $i < 3; $i++) {
             $userRole = new UserRole();

--- a/symfony/plugins/orangehrmCorePlugin/test/authorization/userrole/SupervisorUserRoleTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/authorization/userrole/SupervisorUserRoleTest.php
@@ -36,7 +36,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetSetEmployeeService() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
 
         $this->supervisorUserRole->setEmployeeService($mockService);
         $this->assertEquals($mockService, $this->supervisorUserRole->getEmployeeService());
@@ -45,7 +45,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
     public function testGetAccessibleEmployeeIds() {
 
         
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
         $mockService->expects($this->once())
                 ->method('getSubordinateIdListBySupervisorId')
                 ->will($this->returnValue(array(1, 3)));
@@ -57,7 +57,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleEmployeePropertyList() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
         $properties = array("empNumber", "firstName", "middleName", "lastName", "termination_id");
         $propertyList = new Doctrine_Collection('Employee');
         for ($i = 0; $i < 2; $i++) {
@@ -79,7 +79,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testGetAccessibleEmployees() {
-        $mockService = $this->getMock('EmployeeService');
+        $mockService = $this->getMockBuilder('EmployeeService')->getMock();
         $employeeList = new Doctrine_Collection('Employee');
         for ($i = 0; $i < 2; $i++) {
             $employee = new Employee();
@@ -104,7 +104,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
     }
 //
 //    public function testGetAccessibleLocationIds() {
-//        $mockService = $this->getMock('LocationService');
+//        $mockService = $this->getMockBuilder('LocationService')->getMock();
 //        $locationList = new Doctrine_Collection('Location');
 //        for ($i = 0; $i < 3; $i++) {
 //            $location = new Location();
@@ -122,7 +122,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
 //    }
 //
 //    public function testGetAccessibleOperationalCountryIds() {
-//        $mockService = $this->getMock('OperationalCountryService');
+//        $mockService = $this->getMockBuilder('OperationalCountryService')->getMock();
 //        $opCountryList = new Doctrine_Collection('OperationalCountry');
 //        for ($i = 0; $i < 3; $i++) {
 //            $operationalCountry = new OperationalCountry();
@@ -140,7 +140,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
 //    }
 //
 //    public function testGetAccessibleSystemUserIds() {
-//        $mockService = $this->getMock('SystemUserService');
+//        $mockService = $this->getMockBuilder('SystemUserService')->getMock();
 //
 //        $mockService->expects($this->once())
 //                ->method('getSystemUserIdList')
@@ -152,7 +152,7 @@ class SupervisorUserRoleTest extends PHPUnit_Framework_TestCase {
 //    }
 //
 //    public function testGetAccessibleUserRoleIds() {
-//        $mockService = $this->getMock('SystemUserService');
+//        $mockService = $this->getMockBuilder('SystemUserService')->getMock();
 //        $roleList = new Doctrine_Collection('SystemUser');
 //        for ($i = 0; $i < 3; $i++) {
 //            $userRole = new UserRole();

--- a/symfony/plugins/orangehrmCorePlugin/test/components/CellTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/components/CellTest.php
@@ -75,7 +75,9 @@ class CellTest extends PHPUnit_Framework_TestCase {
         $value = "Test Value";
         $filteredValue = "XYZ Test";
         
-        $mockHeader = $this->getMock('ListHeader', array('filterValue'));
+        $mockHeader = $this->getMockBuilder('ListHeader')
+			->setMethods( array('filterValue'))
+			->getMock();
         $mockHeader->expects($this->once())
                      ->method('filterValue')
                      ->with($value)                

--- a/symfony/plugins/orangehrmCorePlugin/test/model/service/AccessFlowStateMachineServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/model/service/AccessFlowStateMachineServiceTest.php
@@ -49,7 +49,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $fetchedRecord2 = TestDataService::fetchObject('WorkflowStateMachine', 12);
         $recordsArray = array($fetchedRecord1, $fetchedRecord2);
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getAllowedActions'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getAllowedActions'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getAllowedActions')
                 ->with($flow, $state, $role)
@@ -66,7 +68,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $role = "ADMIN";
         $recordsArray = null;
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getAllowedActions'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getAllowedActions'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getAllowedActions')
                 ->with($flow, $state, $role)
@@ -88,7 +92,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $expected->add($fetchedRecord1);
         $expected->add($fetchedRecord2);
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getAllowedWorkflowItems'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getAllowedWorkflowItems'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getAllowedWorkflowItems')
                 ->with($flow, $state, $role)
@@ -108,7 +114,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
 
         $fetchedRecord1 = TestDataService::fetchObject('WorkflowStateMachine', 1);
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getNextState'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getNextState'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getNextState')
                 ->with($flow, $state, $role, $action)
@@ -126,7 +134,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $role = "ADMIN";
         $action = "APPROVE";
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getNextState'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getNextState'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getNextState')
                 ->with($flow, $state, $role, $action)
@@ -148,7 +158,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $fetchedRecord2 = TestDataService::fetchObject('WorkflowStateMachine', 5);
         $tempArray = array($fetchedRecord1, $fetchedRecord2);
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getActionableStates'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getActionableStates'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getActionableStates')
                 ->with($workFlow, $userRole, $actions)
@@ -169,7 +181,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
 
         $workflowStateMachineRecord = $workflowStateMachineRecords[0];
 
-        $accessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('saveWorkflowStateMachineRecord'));
+        $accessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('saveWorkflowStateMachineRecord'))
+			->getMock();
 
         $accessFlowStateMachineDaoMock->expects($this->once())
                 ->method('saveWorkflowStateMachineRecord')
@@ -189,7 +203,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $resultingState = "SUPERVISOR APPROVED";
         $isSuccess = true;
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('deleteWorkflowStateMachineRecord'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('deleteWorkflowStateMachineRecord'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('deleteWorkflowStateMachineRecord')
                 ->with($flow, $state, $role, $action, $resultingState)
@@ -207,7 +223,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $resultingState = "SUPERVISOR APPROVED";
         $isSuccess = false;
 
-        $acessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('deleteWorkflowStateMachineRecord'));
+        $acessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('deleteWorkflowStateMachineRecord'))
+			->getMock();
         $acessFlowStateMachineDaoMock->expects($this->once())
                 ->method('deleteWorkflowStateMachineRecord')
                 ->with($flow, $state, $role, $action, $resultingState)
@@ -224,7 +242,7 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
 
         $workflowStateMachineRecord = $workflowStateMachineRecords[12];
 
-        $accessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao');
+        $accessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')->getMock();
 
         $accessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getWorkFlowStateMachineRecords')
@@ -237,7 +255,7 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testIsActionAllowedService() {
-        $accessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao');
+        $accessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')->getMock();
 
         $accessFlowStateMachineDaoMock->expects($this->once())
                 ->method('isActionAllowed')
@@ -256,7 +274,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $item = new WorkflowStateMachine();
         $item->fromArray(array('id' => 9, 'workflow' => Time, 'state' => 'APPROVED', 'role' => 'SUPERVISOR',
             'action' => 'VIEW TIMESHEET','resulting_state' => 'APPROVED'));
-        $accessFlowStateMachineDaoMock = $this->getMock('AccessFlowStateMachineDao', array('getWorkflowItemByStateActionAndRole'));
+        $accessFlowStateMachineDaoMock = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('getWorkflowItemByStateActionAndRole'))
+			->getMock();
 
         $accessFlowStateMachineDaoMock->expects($this->once())
                 ->method('getWorkflowItemByStateActionAndRole')
@@ -273,7 +293,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $flow = "Time";
         $role = "ADMIN";
 
-        $mockDao = $this->getMock('AccessFlowStateMachineDao', array('deleteWorkflowRecordsForUserRole'));
+        $mockDao = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('deleteWorkflowRecordsForUserRole'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('deleteWorkflowRecordsForUserRole')
                 ->with($flow, $role)
@@ -289,7 +311,9 @@ class AccessFlowStateMachineServiceTest extends PHPUnit_Framework_TestCase {
         $oldName = "ADMIN";
         $newName = "MANAGER";
 
-        $mockDao = $this->getMock('AccessFlowStateMachineDao', array('handleUserRoleRename'));
+        $mockDao = $this->getMockBuilder('AccessFlowStateMachineDao')
+			->setMethods( array('handleUserRoleRename'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('handleUserRoleRename')
                 ->with($oldName, $newName)

--- a/symfony/plugins/orangehrmCorePlugin/test/model/service/ReportGeneratorServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/model/service/ReportGeneratorServiceTest.php
@@ -39,7 +39,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $reportId = 1;
         $report = TestDataService::fetchObject('Report', $reportId);
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getReport'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getReport'))
+			->getMock();
         $reportableServiceMock->expects($this->once())
                 ->method('getReport')
                 ->with($reportId)
@@ -61,7 +63,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $selectedFilterFields->add(TestDataService::fetchObject('SelectedFilterField', array(1, 1)));
         $selectedFilterFields->add(TestDataService::fetchObject('SelectedFilterField', array(1, 2)));
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getReport', 'getSelectedFilterFieldsByType'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getReport', 'getSelectedFilterFieldsByType'))
+			->getMock();
 
         $reportableServiceMock->expects($this->once())
                 ->method('getReport')
@@ -91,7 +95,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $selecteFilterFields->add(TestDataService::fetchObject('SelectedFilterField', array(1, 1)));
         $selecteFilterFields->add(TestDataService::fetchObject('SelectedFilterField', array(1, 2)));
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getSelectedFilterFields'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getSelectedFilterFields'))
+			->getMock();
         $reportableServiceMock->expects($this->once())
                 ->method('getSelectedFilterFields')
                 ->with($reportId, true)
@@ -112,7 +118,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $reportId = 1;
         $report = TestDataService::fetchObject('Report', $reportId);
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getReport'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getReport'))
+			->getMock();
 
         $reportableServiceMock->expects($this->once())
                 ->method('getReport')
@@ -137,7 +145,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $selectedFilterFields->add(TestDataService::fetchObject('SelectedFilterField', array(1, 1)));
         $selectedFilterFields->add(TestDataService::fetchObject('SelectedFilterField', array(1, 2)));
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getReport', 'getSelectedFilterFieldsByType'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getReport', 'getSelectedFilterFieldsByType'))
+			->getMock();
 
         $reportableServiceMock->expects($this->once())
                 ->method('getReport')
@@ -196,7 +206,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $selectedDisplayFields->add(TestDataService::fetchObject('SelectedDisplayField', array(1, 1, 1)));
         $selectedDisplayFields->add(TestDataService::fetchObject('SelectedDisplayField', array(2, 2, 1)));
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getSelectedDisplayFields'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getSelectedDisplayFields'))
+			->getMock();
 
         $reportableServiceMock->expects($this->once())
                 ->method('getSelectedDisplayFields')
@@ -219,7 +231,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $reportGroup = TestDataService::fetchObject('ReportGroup', $reportGroupId);
         $selectedGroupField = TestDataService::fetchObject('SelectedGroupField', array(1, 1, 1));
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getReport', 'getReportGroup', 'getSelectedGroupField'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getReport', 'getReportGroup', 'getSelectedGroupField'))
+			->getMock();
 
         $reportableServiceMock->expects($this->once())
                 ->method('getReport')
@@ -237,7 +251,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
 
         $selectConditionWithoutSummaryFunction = "ohrm_project_activity.name AS activityname";
 
-        $reportGeneratorServiceMock = $this->getMock('ReportGeneratorService', array('getSelectConditionWithoutSummaryFunction'));
+        $reportGeneratorServiceMock = $this->getMockBuilder('ReportGeneratorService')
+			->setMethods( array('getSelectConditionWithoutSummaryFunction'))
+			->getMock();
 
         $reportGeneratorServiceMock->expects($this->once())
                 ->method('getSelectConditionWithoutSummaryFunction')
@@ -258,7 +274,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $activityId = 1;
         $activity = TestDataService::fetchObject('ProjectActivity', $activityId);
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getProjectActivityByActivityId'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getProjectActivityByActivityId'))
+			->getMock();
         $reportableServiceMock->expects($this->once())
                 ->method('getProjectActivityByActivityId')
                 ->with($activityId)
@@ -302,7 +320,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
         $reportGroup = TestDataService::fetchObject('ReportGroup', $reportGroupId);
         $selectedGroupField = TestDataService::fetchObject('SelectedGroupField', array(1, 1, 1));
 
-        $reportableServiceMock = $this->getMock('ReportableService', array('getReport', 'getReportGroup', 'getSelectedGroupField'));
+        $reportableServiceMock = $this->getMockBuilder('ReportableService')
+			->setMethods( array('getReport', 'getReportGroup', 'getSelectedGroupField'))
+			->getMock();
 
         $reportableServiceMock->expects($this->once())
                 ->method('getReport')
@@ -320,7 +340,9 @@ class ReportGeneratorServiceTest extends PHPUnit_Framework_TestCase {
 
         $selectConditionWithoutSummaryFunction = "ohrm_project_activity.name AS activityname";
 
-        $reportGeneratorServiceMock = $this->getMock('ReportGeneratorService', array('getSelectConditionWithoutSummaryFunction'));
+        $reportGeneratorServiceMock = $this->getMockBuilder('ReportGeneratorService')
+			->setMethods( array('getSelectConditionWithoutSummaryFunction'))
+			->getMock();
 
         $reportGeneratorServiceMock->expects($this->once())
                 ->method('getSelectConditionWithoutSummaryFunction')

--- a/symfony/plugins/orangehrmCorePlugin/test/service/ConfigServiceTest.php
+++ b/symfony/plugins/orangehrmCorePlugin/test/service/ConfigServiceTest.php
@@ -24,7 +24,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $dao = $this->configService->getConfigDao();
         $this->assertTrue($dao instanceof ConfigDao);
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $this->configService->setConfigDao($mockDao);
         $dao = $this->configService->getConfigDao();
         $this->assertEquals($dao, $mockDao);
@@ -37,7 +37,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         
         $value = 'Yes';
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_LEAVE_PERIOD_DEFINED, $value);
@@ -61,7 +61,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
     public function testIsLeavePeriodDefined() {
         $value = true;
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_LEAVE_PERIOD_DEFINED)
@@ -78,7 +78,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testSetShowPimDeprecatedFields() {
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_DEPRECATED, 1);
@@ -87,7 +87,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->configService->setShowPimDeprecatedFields(true);
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_DEPRECATED, 0);
@@ -103,7 +103,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testShowPimDeprecatedFields() {
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_DEPRECATED)
@@ -114,7 +114,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $returnVal = $this->configService->showPimDeprecatedFields();
         $this->assertTrue($returnVal);
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_DEPRECATED)
@@ -129,7 +129,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testSetShowPimSSN() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SSN, 1);
@@ -138,7 +138,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->configService->setShowPimSSN(true);
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SSN, 0);
@@ -150,7 +150,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testShowPimSSN() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SSN)
@@ -161,7 +161,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $returnVal = $this->configService->showPimSSN();
         $this->assertTrue($returnVal);
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SSN)
@@ -175,7 +175,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testSetShowPimSIN() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SIN, 1);
@@ -184,7 +184,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->configService->setShowPimSIN(true);
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SIN, 0);
@@ -196,7 +196,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testShowPimSIN() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SIN)
@@ -207,7 +207,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $returnVal = $this->configService->showPimSIN();
         $this->assertTrue($returnVal);
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_SIN)
@@ -221,7 +221,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testSetShowPimTaxExemptions() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_TAX_EXEMPTIONS, 1);
@@ -230,7 +230,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->configService->setShowPimTaxExemptions(true);
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_TAX_EXEMPTIONS, 0);
@@ -240,7 +240,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $this->configService->setShowPimTaxExemptions(false);      
         
         // Exception
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_PIM_SHOW_TAX_EXEMPTIONS, 0)
@@ -259,7 +259,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testShowPimTaxExemptions() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_TAX_EXEMPTIONS)
@@ -270,7 +270,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $returnVal = $this->configService->showPimTaxExemptions();
         $this->assertTrue($returnVal);
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_TAX_EXEMPTIONS)
@@ -282,7 +282,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($returnVal);         
         
         // Exception
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_PIM_SHOW_TAX_EXEMPTIONS)
@@ -302,7 +302,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testSetSupervisorChainSuported() {
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_INCLUDE_SUPERVISOR_CHAIN, 'Yes');
@@ -311,7 +311,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->configService->setSupervisorChainSuported(true);
         
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with(ConfigService::KEY_INCLUDE_SUPERVISOR_CHAIN, 'No');
@@ -324,7 +324,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testIsSupervisorChainSuported() {
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_INCLUDE_SUPERVISOR_CHAIN)
@@ -335,7 +335,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
         $returnVal = $this->configService->isSupervisorChainSuported();
         $this->assertTrue($returnVal);
 
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with(ConfigService::KEY_INCLUDE_SUPERVISOR_CHAIN)
@@ -371,7 +371,9 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testGetAllValues() {
         $allValues = array('k1' => 'v1', 'k2' => 'v2');
-        $mockDao = $this->getMock('ConfigDao', array('getAllValues'));
+        $mockDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getAllValues'))
+			->getMock();
         $mockDao->expects($this->once())
                  ->method('getAllValues')
                  ->will($this->returnValue($allValues));
@@ -381,7 +383,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     protected function validateGetMethod($method, $key, $expected) {        
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getValue')
                  ->with($key)
@@ -394,7 +396,7 @@ class ConfigServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     protected function validateSetMethod($method, $key, $value) {        
-        $mockDao = $this->getMock('ConfigDao');
+        $mockDao = $this->getMockBuilder('ConfigDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('setValue')
                  ->with($key, $value);

--- a/symfony/plugins/orangehrmCoreWebServicePlugin/test/lib/utility/WSHelperTest.php
+++ b/symfony/plugins/orangehrmCoreWebServicePlugin/test/lib/utility/WSHelperTest.php
@@ -55,8 +55,11 @@ class WSHelperTest extends PHPUnit_Framework_TestCase {
      * @covers WSHelper::extractParameters
      */
     public function testExtractParameters() {
-        $requestMock = $this->getMock('sfWebRequest', array('getMethod', 'getHttpHeader', 'getRequestParameters', 'getContentType'), 
-            array(new sfEventDispatcher()));
+        $requestMock = $this->getMockBuilder('sfWebRequest')
+            ->setMethods(array('getMethod', 'getHttpHeader', 'getRequestParameters', 'getContentType'))
+            ->setConstructorArgs(array(new sfEventDispatcher()))
+            ->getMock();
+
         $requestMock->expects($this->once())
                 ->method('getMethod')
                 ->will($this->returnValue('GET'));
@@ -90,7 +93,10 @@ class WSHelperTest extends PHPUnit_Framework_TestCase {
      * @expectedException WebServiceException
      */
     public function testextractParameters_InvalidAuthParameterHeaders() {
-        $requestMock = $this->getMock('sfWebRequest', array('getMethod', 'getHttpHeader', 'getRequestParameters'), array(new sfEventDispatcher()));
+        $requestMock = $this->getMockBuilder('sfWebRequest')
+			->setMethods( array('getMethod', 'getHttpHeader', 'getRequestParameters'))
+            ->setConstructorArgs(array(new sfEventDispatcher()))
+			->getMock();
         $requestMock->expects($this->once())
                 ->method('getMethod')
                 ->will($this->returnValue('GET'));
@@ -116,7 +122,10 @@ class WSHelperTest extends PHPUnit_Framework_TestCase {
      * @expectedException WebServiceException
      */
     public function testextractParameters_WithEmptyModuleAndMethod() {
-        $requestMock = $this->getMock('sfWebRequest', array('getMethod', 'getHttpHeader', 'getRequestParameters'), array(new sfEventDispatcher()));
+        $requestMock = $this->getMockBuilder('sfWebRequest')
+			->setMethods( array('getMethod', 'getHttpHeader', 'getRequestParameters'))
+            ->setConstructorArgs(array(new sfEventDispatcher()))
+			->getMock();
         $requestMock->expects($this->once())
                 ->method('getMethod')
                 ->will($this->returnValue('GET'));
@@ -146,7 +155,9 @@ class WSHelperTest extends PHPUnit_Framework_TestCase {
 
         $expcetedString = json_encode($result);
 
-        $wsUtilityServiceMock = $this->getMock('WSUtilityService', array('format'));
+        $wsUtilityServiceMock = $this->getMockBuilder('WSUtilityService')
+			->setMethods( array('format'))
+			->getMock();
         $wsUtilityServiceMock->expects($this->once())
                 ->method('format')
                 ->will($this->returnValue(json_encode($result)));

--- a/symfony/plugins/orangehrmCorporateDirectoryPlugin/test/model/service/EmployeeDirectoryServiceTest.php
+++ b/symfony/plugins/orangehrmCorporateDirectoryPlugin/test/model/service/EmployeeDirectoryServiceTest.php
@@ -35,7 +35,7 @@ class EmployeeDirectoryServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testGetSetEmployeeDirectoryDao() {
-        $mockDao = $this->getMock('EmployeeDirectoryDao');
+        $mockDao = $this->getMockBuilder('EmployeeDirectoryDao')->getMock();
                 
         $this->employeeDirectoryService->setEmployeeDirectoryDao($mockDao);
         $this->assertEquals($mockDao, $this->employeeDirectoryService->getEmployeeDirectoryDao());        
@@ -56,7 +56,7 @@ class EmployeeDirectoryServiceTest extends PHPUnit_Framework_TestCase {
 //            $employees[] = $employee;
 //        }             
 //        
-//        $mockDao = $this->getMock('EmployeeDao');
+//        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
 //        $mockDao->expects($this->once())
 //                 ->method('searchEmployee')
 //                 ->with($field, $value)
@@ -83,7 +83,7 @@ class EmployeeDirectoryServiceTest extends PHPUnit_Framework_TestCase {
                 
         $list   =   array( $employee1,$employee2);
         
-        $mockDao = $this->getMock('EmployeeDirectoryDao');
+        $mockDao = $this->getMockBuilder('EmployeeDirectoryDao')->getMock();
         $mockDao->expects($this->once())
              ->method('searchEmployees')
              ->with($parameterHolder)   
@@ -102,7 +102,7 @@ class EmployeeDirectoryServiceTest extends PHPUnit_Framework_TestCase {
 
         $count = 20;         
         
-        $mockDao = $this->getMock('EmployeeDirectoryDao');
+        $mockDao = $this->getMockBuilder('EmployeeDirectoryDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getSearchEmployeeCount')
                  ->will($this->returnValue($count));

--- a/symfony/plugins/orangehrmCorporateDirectoryPlugin/test/model/wrapper/CorporateDirectoryWebServiceHelperTest.php
+++ b/symfony/plugins/orangehrmCorporateDirectoryPlugin/test/model/wrapper/CorporateDirectoryWebServiceHelperTest.php
@@ -42,7 +42,7 @@ class CorporateDirectoryWebServiceHelperTest extends PHPUnit_Framework_TestCase 
             $employee
         );
 
-        $employeeDirectoryServiceMock = $this->getMock('EmployeeDirectoryService');
+        $employeeDirectoryServiceMock = $this->getMockBuilder('EmployeeDirectoryService')->getMock();
         $employeeDirectoryServiceMock->expects($this->once())
                 ->method('searchEmployees')
                 ->will($this->returnValue($employees));
@@ -79,7 +79,7 @@ class CorporateDirectoryWebServiceHelperTest extends PHPUnit_Framework_TestCase 
             $employee
         );
 
-        $employeeDirectoryServiceMock = $this->getMock('EmployeeDirectoryService');
+        $employeeDirectoryServiceMock = $this->getMockBuilder('EmployeeDirectoryService')->getMock();
         $employeeDirectoryServiceMock->expects($this->once())
                 ->method('searchEmployees')
                 ->will($this->returnValue($employees));
@@ -112,7 +112,7 @@ class CorporateDirectoryWebServiceHelperTest extends PHPUnit_Framework_TestCase 
             $employee
         );
 
-        $employeeDirectoryServiceMock = $this->getMock('EmployeeDirectoryService');
+        $employeeDirectoryServiceMock = $this->getMockBuilder('EmployeeDirectoryService')->getMock();
         $employeeDirectoryServiceMock->expects($this->once())
                 ->method('searchEmployees')
                 ->will($this->returnValue($employees));
@@ -120,7 +120,7 @@ class CorporateDirectoryWebServiceHelperTest extends PHPUnit_Framework_TestCase 
                 ->method('getSearchEmployeeCount')
                 ->will($this->returnValue($count));
 
-        $employeeServiceMock = $this->getMock('EmployeeService');
+        $employeeServiceMock = $this->getMockBuilder('EmployeeService')->getMock();
         $employeeServiceMock->expects($this->once())
                 ->method('getEmployeePicture')
                 ->will($this->returnValue($empPicture));
@@ -143,7 +143,7 @@ class CorporateDirectoryWebServiceHelperTest extends PHPUnit_Framework_TestCase 
             $employee
         );
 
-        $employeeDirectoryServiceMock = $this->getMock('EmployeeDirectoryService');
+        $employeeDirectoryServiceMock = $this->getMockBuilder('EmployeeDirectoryService')->getMock();
         $employeeDirectoryServiceMock->expects($this->once())
                 ->method('searchEmployees')
                 ->will($this->returnValue($employees));
@@ -151,7 +151,7 @@ class CorporateDirectoryWebServiceHelperTest extends PHPUnit_Framework_TestCase 
                 ->method('getSearchEmployeeCount')
                 ->will($this->returnValue($count));
 
-        $employeeServiceMock = $this->getMock('EmployeeService');
+        $employeeServiceMock = $this->getMockBuilder('EmployeeService')->getMock();
         $employeeServiceMock->expects($this->once())
                 ->method('getEmployeePicture')
                 ->will($this->returnValue(null));

--- a/symfony/plugins/orangehrmLeavePlugin/test/entitlement/FIFOEntitlementConsumptionStrategyTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/entitlement/FIFOEntitlementConsumptionStrategyTest.php
@@ -56,7 +56,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array();
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'to_date', 'ASC')
@@ -101,7 +101,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -149,7 +149,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -196,7 +196,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -242,7 +242,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -293,7 +293,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -349,7 +349,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1, $entitlement2
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-15', 'to_date', 'ASC')
@@ -413,7 +413,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1, $entitlement2
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -521,7 +521,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1, $entitlement2, $entitlement3, $entitlement4, $entitlement5
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -632,7 +632,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1, $entitlement2, $entitlement3, $entitlement4, $entitlement5
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -744,7 +744,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1, $entitlement2, $entitlement3, $entitlement4, $entitlement5
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-16', 'to_date', 'ASC')
@@ -858,7 +858,7 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
             $entitlement1, $entitlement2, $entitlement3, $entitlement4, $entitlement5
         );
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements', 'getLinkedLeaveRequests'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')->setMethods(array('getValidLeaveEntitlements', 'getLinkedLeaveRequests'))->getMock();
         $mockService->expects($this->any())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-13', '2012-09-14', 'to_date', 'ASC')

--- a/symfony/plugins/orangehrmLeavePlugin/test/entitlement/FIFOEntitlementConsumptionStrategyTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/entitlement/FIFOEntitlementConsumptionStrategyTest.php
@@ -896,7 +896,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array();
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->exactly(2))
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -943,7 +945,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -985,7 +989,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -1032,7 +1038,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -1073,7 +1081,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -1120,7 +1130,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-13', 'from_date', 'ASC')
@@ -1163,7 +1175,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-13', 'from_date', 'ASC')
@@ -1207,7 +1221,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -1251,7 +1267,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
 
         $entitlements = array($entitlement1);
 
-        $mockService = $this->getMock('LeaveEntitlementService', array('getValidLeaveEntitlements'));
+        $mockService = $this->getMockBuilder('LeaveEntitlementService')
+			->setMethods( array('getValidLeaveEntitlements'))
+			->getMock();
         $mockService->expects($this->once())
                 ->method('getValidLeaveEntitlements')
                 ->with($empNumber, $leaveType, '2012-09-11', '2012-09-12', 'from_date', 'ASC')
@@ -1266,7 +1284,9 @@ class FIFOEntitlementConsumptionStrategyTest extends PHPUnit_Framework_TestCase 
     
     public function testGetLeaveWithoutEntitlementDateLimitsForLeaveBalance() {
         
-        $mockService = $this->getMock('LeavePeriodService', array('getCurrentLeavePeriodByDate'));
+        $mockService = $this->getMockBuilder('LeavePeriodService')
+			->setMethods( array('getCurrentLeavePeriodByDate'))
+			->getMock();
         $mockService->expects($this->any())
                 ->method('getCurrentLeavePeriodByDate')
                 ->will($this->returnValue(array('2012-01-01', '2012-12-31')));

--- a/symfony/plugins/orangehrmLeavePlugin/test/mail/LeaveMailerTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/mail/LeaveMailerTest.php
@@ -41,7 +41,7 @@ class LeaveMailerTest extends PHPUnit_Framework_TestCase {
         
         $recipientRoles = array('ESS', 'Supervisor', 'ABC');
         
-        $mockService = $this->getMock('EmailService', array('sendEmailNotifications'));
+        $mockService = $this->getMockBuilder('EmailService')->setMethods(array('sendEmailNotifications'))->getMock();
         $mockService->expects($this->once())
                 ->method('sendEmailNotifications')
                 ->with($emailType, $recipientRoles, $eventData, 'ess');

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/dao/LeaveEntitlementDaoTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/dao/LeaveEntitlementDaoTest.php
@@ -416,7 +416,9 @@ class LeaveEntitlementDaoTest extends PHPUnit_Framework_TestCase {
         
         $unlinkedDateLimits = array('2001-01-01', '2020-01-01');
         
-        $mockStrategy = $this->getMock('FIFOEntitlementConsumptionStrategy', array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'));
+        $mockStrategy = $this->getMockBuilder('FIFOEntitlementConsumptionStrategy')
+			->setMethods( array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'))
+			->getMock();
         $mockStrategy->expects($this->any())
                     ->method('getLeaveWithoutEntitlementDateLimitsForLeaveBalance')
                     //->with($parameterHolder)
@@ -587,7 +589,9 @@ class LeaveEntitlementDaoTest extends PHPUnit_Framework_TestCase {
         
         $unlinkedDateLimits = array('2013-01-01', '2013-12-31');
         
-        $mockStrategy = $this->getMock('FIFOEntitlementConsumptionStrategy', array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'));
+        $mockStrategy = $this->getMockBuilder('FIFOEntitlementConsumptionStrategy')
+			->setMethods( array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'))
+			->getMock();
         $mockStrategy->expects($this->once())
                     ->method('getLeaveWithoutEntitlementDateLimitsForLeaveBalance')
                     ->with('2013-01-01', '2013-12-31')
@@ -605,7 +609,9 @@ class LeaveEntitlementDaoTest extends PHPUnit_Framework_TestCase {
     public function testGetLeaveBalanceExcludingUnlinkedLeaveWhenAfterPeriod() {
         $unlinkedDateLimits = array('2013-01-01', '2014-12-31');
         
-        $mockStrategy = $this->getMock('FIFOEntitlementConsumptionStrategy', array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'));
+        $mockStrategy = $this->getMockBuilder('FIFOEntitlementConsumptionStrategy')
+			->setMethods( array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'))
+			->getMock();
         $mockStrategy->expects($this->once())
                     ->method('getLeaveWithoutEntitlementDateLimitsForLeaveBalance')
                     ->with('2013-01-01', '2013-12-31')
@@ -623,7 +629,9 @@ class LeaveEntitlementDaoTest extends PHPUnit_Framework_TestCase {
     public function testGetLeaveBalanceExcludingUnlinkedBeforePeriod() {
         $unlinkedDateLimits = array('2012-01-01', '2013-12-31');
         
-        $mockStrategy = $this->getMock('FIFOEntitlementConsumptionStrategy', array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'));
+        $mockStrategy = $this->getMockBuilder('FIFOEntitlementConsumptionStrategy')
+			->setMethods( array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'))
+			->getMock();
         $mockStrategy->expects($this->once())
                     ->method('getLeaveWithoutEntitlementDateLimitsForLeaveBalance')
                     ->with('2013-01-01', '2013-12-31')
@@ -640,7 +648,9 @@ class LeaveEntitlementDaoTest extends PHPUnit_Framework_TestCase {
     
     public function testGetLeaveBalanceExcludingUnlinkedLeave() {
         
-        $mockStrategy = $this->getMock('FIFOEntitlementConsumptionStrategy', array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'));
+        $mockStrategy = $this->getMockBuilder('FIFOEntitlementConsumptionStrategy')
+			->setMethods( array('getLeaveWithoutEntitlementDateLimitsForLeaveBalance'))
+			->getMock();
         $mockStrategy->expects($this->once())
                     ->method('getLeaveWithoutEntitlementDateLimitsForLeaveBalance')
                     ->with('2013-01-01', '2013-12-31')

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/dao/WorkWeekDaoTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/dao/WorkWeekDaoTest.php
@@ -116,7 +116,9 @@ class WorkWeekDaoTest extends PHPUnit_Framework_TestCase {
      */
     public function testSaveWorkWeekException() {
 
-        $workWeek = $this->getMock('WorkWeek', array('save'));
+        $workWeek = $this->getMockBuilder('WorkWeek')
+			->setMethods( array('save'))
+			->getMock();
         $workWeek->expects($this->once())
                 ->method('save')
                 ->will($this->throwException(new Exception()));

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/HolidayServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/HolidayServiceTest.php
@@ -50,7 +50,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
         $holiday    = $holidays[0];
 
-        $holidayDao = $this->getMock('HolidayDao', array('saveHoliday'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('saveHoliday'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('saveHoliday')
                 ->with($holiday)
@@ -68,7 +70,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHoliday'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('readHoliday'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHoliday')
                 ->with(1)
@@ -86,7 +90,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testReadHolidayReturnsNullInDao() {
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHoliday'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('readHoliday'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHoliday')
                 ->with(10)
@@ -103,7 +109,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testDeleteHoliday() {
 
-        $holidayDao = $this->getMock('HolidayDao', array('deleteHoliday'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('deleteHoliday'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('deleteHoliday')
                 ->with(array(1,2))
@@ -120,7 +128,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('readHolidayByDate'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("2010-05-27")
@@ -135,7 +145,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testReadHolidayByDateReturnsNullInDao() {
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('readHolidayByDate'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("5555-10-21")
@@ -185,7 +197,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetHolidayList() {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
-        $holidayDao = $this->getMock('HolidayDao', array('getHolidayList'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('getHolidayList'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('getHolidayList')
                 ->will($this->returnValue($holidays));
@@ -205,7 +219,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetFullHolidayList() {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
-        $holidayDao = $this->getMock('HolidayDao', array('getFullHolidayList'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('getFullHolidayList'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('getFullHolidayList')
                 ->will($this->returnValue($holidays));
@@ -299,7 +315,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays = TestDataService::loadObjectListFromArray('Holiday', $fixture);
 
-        $holidayDao = $this->getMock('HolidayDao', array('searchHolidays'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('searchHolidays'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('searchHolidays')
                 ->will($this->returnValue($holidays));
@@ -320,7 +338,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
         
         $holidays = TestDataService::loadObjectListFromArray('Holiday', $fixture);
 
-        $holidayDao = $this->getMock('HolidayDao', array('searchHolidays'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('searchHolidays'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('searchHolidays')
                 ->will($this->returnValue($holidays));
@@ -343,7 +363,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
         
         $holidays = TestDataService::loadObjectListFromArray('Holiday', $fixture);
 
-        $holidayDao = $this->getMock('HolidayDao', array('searchHolidays'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('searchHolidays'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('searchHolidays')
                 ->will($this->returnValue($holidays));
@@ -377,7 +399,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
         
         $holidays = TestDataService::loadObjectListFromArray('Holiday', $fixture);
 
-        $holidayDao = $this->getMock('HolidayDao', array('searchHolidays'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('searchHolidays'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('searchHolidays')
                 ->will($this->returnValue($holidays));
@@ -440,7 +464,9 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
         
         $holidays = TestDataService::loadObjectListFromArray('Holiday', $fixture);
 
-        $holidayDao = $this->getMock('HolidayDao', array('searchHolidays'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')
+			->setMethods( array('searchHolidays'))
+			->getMock();
         $holidayDao->expects($this->once())
                 ->method('searchHolidays')
                 ->will($this->returnValue($holidays));

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/HolidayServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/HolidayServiceTest.php
@@ -164,7 +164,7 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')->setMethods(array('readHolidayByDate'))->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("2010-05-28")
@@ -181,7 +181,7 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')->setMethods(array('readHolidayByDate'))->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("5555-10-21")
@@ -242,7 +242,7 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
     public function testIsHalfDay() {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')->setMethods(array('readHolidayByDate'))->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("2010-05-28")
@@ -258,7 +258,7 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
     public function testIsHalfDayReturnsFalse() {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')->setMethods(array('readHolidayByDate'))->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("5555-10-21")
@@ -275,7 +275,7 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')->setMethods(array('readHolidayByDate'))->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("2010-05-27")
@@ -292,7 +292,7 @@ class HolidayServiceTest extends PHPUnit_Framework_TestCase {
 
         $holidays   = TestDataService::loadObjectList('Holiday', $this->fixture, 'Holiday');
 
-        $holidayDao = $this->getMock('HolidayDao', array('readHolidayByDate'));
+        $holidayDao = $this->getMockBuilder('HolidayDao')->setMethods(array('readHolidayByDate'))->getMock();
         $holidayDao->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with("2010-05-28")

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveConfigurationServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveConfigurationServiceTest.php
@@ -37,7 +37,9 @@ class LeaveConfigurationServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetLeaveEntitlementConsumptionStrategy() {
         
         $strategy = "FIFO";
-        $mockDao = $this->getMock('ConfigDao', array('getValue'));
+        $mockDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $mockDao->expects($this->once())
                     ->method('getValue')
                     ->with(LeaveConfigurationService::KEY_LEAVE_ENTITLEMENT_CONSUMPTION_STRATEGY)
@@ -50,7 +52,9 @@ class LeaveConfigurationServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testGetWorkScheduleImplementation() {
         $implementation = "Basic";
-        $mockDao = $this->getMock('ConfigDao', array('getValue'));
+        $mockDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $mockDao->expects($this->once())
                     ->method('getValue')
                     ->with(LeaveConfigurationService::KEY_LEAVE_WORK_SCHEDULE_IMPLEMENTATION)

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveEntitlementServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveEntitlementServiceTest.php
@@ -41,7 +41,9 @@ class LeaveEntitlementServiceTest extends PHPUnit_Framework_TestCase {
         $leaveEntitlements  = TestDataService::loadObjectList('LeaveEntitlement', $this->fixture, 'LeaveEntitlement');
         $parameterHolder = new LeaveEntitlementSearchParameterHolder();
 
-        $mockDao = $this->getMock('LeaveEntitlementDao', array('searchLeaveEntitlements'));
+        $mockDao = $this->getMockBuilder('LeaveEntitlementDao')
+			->setMethods( array('searchLeaveEntitlements'))
+			->getMock();
         $mockDao->expects($this->once())
                     ->method('searchLeaveEntitlements')
                     ->with($parameterHolder)
@@ -57,7 +59,9 @@ class LeaveEntitlementServiceTest extends PHPUnit_Framework_TestCase {
         $leaveEntitlements  = TestDataService::loadObjectList('LeaveEntitlement', $this->fixture, 'LeaveEntitlement');
         $leaveEntitlement = $leaveEntitlements[0];
 
-        $mockDao = $this->getMock('LeaveEntitlementDao', array('saveLeaveEntitlement'));
+        $mockDao = $this->getMockBuilder('LeaveEntitlementDao')
+			->setMethods( array('saveLeaveEntitlement'))
+			->getMock();
         $mockDao->expects($this->once())
                     ->method('saveLeaveEntitlement')
                     ->with($leaveEntitlement)
@@ -84,7 +88,9 @@ class LeaveEntitlementServiceTest extends PHPUnit_Framework_TestCase {
         $leaveEntitlements = array($leaveEntitlement1, $leaveEntitlement2, $leaveEntitlement3);
         
         
-        $mockDao = $this->getMock('LeaveEntitlementDao', array('deleteLeaveEntitlements', 'searchLeaveEntitlements'));
+        $mockDao = $this->getMockBuilder('LeaveEntitlementDao')
+			->setMethods( array('deleteLeaveEntitlements', 'searchLeaveEntitlements'))
+			->getMock();
         $mockDao->expects($this->once())
                     ->method('deleteLeaveEntitlements')
                     ->with($ids)
@@ -106,7 +112,9 @@ class LeaveEntitlementServiceTest extends PHPUnit_Framework_TestCase {
         $leaveEntitlements = TestDataService::loadObjectList('LeaveEntitlement', $this->fixture, 'LeaveEntitlement');
         $leaveEntitlement = $leaveEntitlements[0];
 
-        $mockDao = $this->getMock('LeaveEntitlementDao', array('getLeaveEntitlement'));
+        $mockDao = $this->getMockBuilder('LeaveEntitlementDao')
+			->setMethods( array('getLeaveEntitlement'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('getLeaveEntitlement')
                 ->with($id)
@@ -127,7 +135,9 @@ class LeaveEntitlementServiceTest extends PHPUnit_Framework_TestCase {
         $fromDate = $leaveEntitlement->getFromDate();
         $toDate = $leaveEntitlement->getToDate();
         
-        $mockDao = $this->getMock('LeaveEntitlementDao', array('getMatchingEntitlements'));
+        $mockDao = $this->getMockBuilder('LeaveEntitlementDao')
+			->setMethods( array('getMatchingEntitlements'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('getMatchingEntitlements')
                 ->with($empNumber, $leaveTypeId, $fromDate, $toDate)
@@ -150,7 +160,9 @@ class LeaveEntitlementServiceTest extends PHPUnit_Framework_TestCase {
         $leaveEntitlementType->setName('ADD');
         $leaveEntitlementTypeList[] = $leaveEntitlementType;        
         
-        $mockDao = $this->getMock('LeaveEntitlementDao', array('getLeaveEntitlementTypeList'));
+        $mockDao = $this->getMockBuilder('LeaveEntitlementDao')
+			->setMethods( array('getLeaveEntitlementTypeList'))
+			->getMock();
         $mockDao->expects($this->once())
                 ->method('getLeaveEntitlementTypeList')
                 ->with($sortField, $sortOrder)

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeavePeriodServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeavePeriodServiceTest.php
@@ -225,7 +225,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
         $leavePeriod   = $leavePeriods[0];
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('saveLeavePeriod'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('saveLeavePeriod'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                      ->method('saveLeavePeriod')
                      ->with($leavePeriod)
@@ -245,7 +247,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $leavePeriod   = $leavePeriods[0];
         $timestamp     = strtotime('2008-02-01');
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                          ->method('filterByTimestamp')
                          ->with($timestamp)
@@ -267,7 +271,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
         $timestamp     = strtotime('+2 day', strtotime('2009-01-31'));
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                         ->method('filterByTimestamp')
                         ->will($this->returnValue($leavePeriods[1]));
@@ -288,7 +294,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
         $timestamp     = strtotime('5500-11-12');
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                         ->method('filterByTimestamp')
                         ->will($this->returnValue(null));
@@ -308,7 +316,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
     public function testAdjustCurrentLeavePeriod() {
 
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp', 'saveLeavePeriod', 'readLeavePeriod'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp', 'saveLeavePeriod', 'readLeavePeriod'))
+			->getMock();
 
         $leavePeriodDao->expects($this->any())
                         ->method('filterByTimestamp')
@@ -334,7 +344,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
 
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('findLastLeavePeriod', 'filterByTimestamp'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('findLastLeavePeriod', 'filterByTimestamp'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                         ->method('findLastLeavePeriod')
                         ->with('2010-01-30')
@@ -366,7 +378,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
 
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('findLastLeavePeriod', 'filterByTimestamp', 'saveLeavePeriod'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('findLastLeavePeriod', 'filterByTimestamp', 'saveLeavePeriod'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                         ->method('findLastLeavePeriod')
                         ->with('2010-01-30')
@@ -397,7 +411,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testCreateNextLeavePeriodReturnsNull() {
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('findLastLeavePeriod'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('findLastLeavePeriod'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                         ->method('findLastLeavePeriod')
                         ->with('1000-10-10')
@@ -417,7 +433,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
 
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('getLeavePeriodList'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('getLeavePeriodList'))
+			->getMock();
 
         $leavePeriodDao->expects($this->once())
                         ->method('getLeavePeriodList')
@@ -440,7 +458,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
 
         $leavePeriods  = TestDataService::loadObjectList('LeavePeriod', $this->fixture, 'LeavePeriod');
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp'))
+			->getMock();
 
         $leavePeriodDao->expects($this->any())
                         ->method('filterByTimestamp')
@@ -470,7 +490,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $leavePeriod->setStartDate("2010-01-01");
         $leavePeriod->setEndDate("2010-12-31");
         $leavePeriod->setLeavePeriodId(1);
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                 ->method('filterByTimestamp')
                 ->will($this->returnValue($leavePeriod));
@@ -490,7 +512,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $lastLeavePeriod->setEndDate("2010-12-31");
         $lastLeavePeriod->setLeavePeriodId(1);
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('filterByTimestamp', 'findLastLeavePeriod', 'saveLeavePeriod'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('filterByTimestamp', 'findLastLeavePeriod', 'saveLeavePeriod'))
+			->getMock();
         $leavePeriodDao->expects($this->any())
                 ->method('filterByTimestamp')
                 ->will($this->returnValue(null));
@@ -518,7 +542,9 @@ class LeavePeriodServiceTest extends PHPUnit_Framework_TestCase {
         $lastLeavePeriod->setEndDate("2010-12-31");
         $lastLeavePeriod->setLeavePeriodId(1);
 
-        $leavePeriodDao = $this->getMock('LeavePeriodDao', array('readLeavePeriod'));
+        $leavePeriodDao = $this->getMockBuilder('LeavePeriodDao')
+			->setMethods( array('readLeavePeriod'))
+			->getMock();
         $leavePeriodDao->expects($this->once())
                 ->method('readLeavePeriod')
                 ->will($this->returnValue($lastLeavePeriod));

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveRequestServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveRequestServiceTest.php
@@ -205,7 +205,7 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $leaveRequestList = TestDataService::loadObjectList('LeaveRequest', $this->fixture, 'set3');
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set4');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('modifyOverlapLeaveRequest'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')->setMethods(array('modifyOverlapLeaveRequest'))->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('modifyOverlapLeaveRequest')
                 ->with($leaveRequestList[0], $leaveList)
@@ -812,7 +812,7 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         
         $actions = array($approveAction, $cancelAction, $rejectAction);
         
-        $leave = $this->getMock('LeaveRequest', array('isStatusDiffer', 'getEmpNumber', 'getLeaveStatusId'));
+        $leave = $this->getMockBuilder('LeaveRequest')->setMethods(array('isStatusDiffer', 'getEmpNumber', 'getLeaveStatusId'))->getMock();
         $leave->expects($this->once())
               ->method('isStatusDiffer')
               ->will($this->returnValue(false));
@@ -823,7 +823,7 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
               ->method('getLeaveStatusId')
               ->will($this->returnValue(Leave::LEAVE_STATUS_LEAVE_PENDING_APPROVAL));        
         
-        $userManager = $this->getMock('BasicUserRoleManager', array('getAllowedActions'));
+        $userManager = $this->getMockBuilder('BasicUserRoleManager')->setMethods(array('getAllowedActions'))->getMock();
         $userManager->expects($this->any())
                     ->method('getAllowedActions')
                     ->with(WorkflowStateMachine::FLOW_LEAVE, 
@@ -845,7 +845,7 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
             'resulting_state' => 'CANCELLED','roles_to_notify' => '','priority' => 0));           
         $actions = array($cancelAction);
         
-        $leave = $this->getMock('LeaveRequest', array('isStatusDiffer', 'getEmpNumber', 'getLeaveStatusId'));
+        $leave = $this->getMockBuilder('LeaveRequest')->setMethods(array('isStatusDiffer', 'getEmpNumber', 'getLeaveStatusId'))->getMock();
         $leave->expects($this->once())
               ->method('isStatusDiffer')
               ->will($this->returnValue(false));
@@ -856,7 +856,7 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
               ->method('getLeaveStatusId')
               ->will($this->returnValue(Leave::LEAVE_STATUS_LEAVE_PENDING_APPROVAL));        
         
-        $userManager = $this->getMock('BasicUserRoleManager', array('getAllowedActions'));
+        $userManager = $this->getMockBuilder('BasicUserRoleManager')->setMethods(array('getAllowedActions'))->getMock();
         $userManager->expects($this->any())
                     ->method('getAllowedActions')
                     ->with(WorkflowStateMachine::FLOW_LEAVE, 

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveRequestServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveRequestServiceTest.php
@@ -45,7 +45,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $leaveRequestList = TestDataService::loadObjectList('LeaveRequest', $this->fixture, 'set1');
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set2');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('saveLeaveRequest'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('saveLeaveRequest'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('saveLeaveRequest')
                 ->with($leaveRequestList[0], $leaveList)
@@ -62,7 +64,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
     public function xtestGetNumOfLeave() {
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getNumOfLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getNumOfLeave'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('getNumOfLeave')
                 ->with(1, 'LTY001')
@@ -78,7 +82,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
     public function xtestGetNumOfAvaliableLeave() {
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getNumOfAvaliableLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getNumOfAvaliableLeave'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('getNumOfAvaliableLeave')
                 ->with(1, 'LTY002')
@@ -96,7 +102,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $leaveRequestList = TestDataService::loadObjectList('LeaveRequest', $this->fixture, 'set1');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('fetchLeaveRequest'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('fetchLeaveRequest'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('fetchLeaveRequest')
                 ->with(1)
@@ -120,7 +128,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set2');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('fetchLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('fetchLeave'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('fetchLeave')
                 ->with(1)
@@ -156,7 +166,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
     public function xtestGetScheduledLeavesSum() {
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getScheduledLeavesSum'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getScheduledLeavesSum'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('getScheduledLeavesSum')
                 ->with(1, 'LTY001', 1)
@@ -172,7 +184,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
     public function xtestGetTakenLeaveSum() {
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getTakenLeaveSum'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getTakenLeaveSum'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('getTakenLeaveSum')
                 ->with(5, 'LTY002', 1)
@@ -213,7 +227,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $leaveRequestList = TestDataService::loadObjectList('LeaveRequest', $this->fixture, 'set1');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('searchLeaveRequests'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('searchLeaveRequests'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('searchLeaveRequests')
                 ->with($searchParameters, 1)
@@ -235,14 +251,18 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $leaveTypes = TestDataService::loadObjectList('LeaveType', $this->fixture, 'set5');
 
         //mocking LeaveTypeService
-        $leaveTypeService = $this->getMock('LeaveTypeService', array('getLeaveTypeList'));
+        $leaveTypeService = $this->getMockBuilder('LeaveTypeService')
+			->setMethods( array('getLeaveTypeList'))
+			->getMock();
         $leaveTypeService->expects($this->once())
                 ->method('getLeaveTypeList')
                 ->will($this->returnValue($leaveTypes));
         $this->leaveRequestService->setLeaveTypeService($leaveTypeService);
 
         //mocking LeaveEntitlementService
-        $leaveEntitlementService = $this->getMock('OldLeaveEntitlementService', array('getLeaveBalance'));
+        $leaveEntitlementService = $this->getMockBuilder('OldLeaveEntitlementService')
+			->setMethods( array('getLeaveBalance'))
+			->getMock();
         $leaveEntitlementService->expects($this->any())
                 ->method('getLeaveBalance')
                 ->will($this->returnValue(2));
@@ -253,7 +273,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $leavePeriod->setStartDate("2010-01-01");
         $leavePeriod->setEndDate("2010-12-31");
         $leavePeriod->setLeavePeriodId(1);
-        $leavePeriodService = $this->getMock('LeavePeriodService', array('getCurrentLeavePeriod'));
+        $leavePeriodService = $this->getMockBuilder('LeavePeriodService')
+			->setMethods( array('getCurrentLeavePeriod'))
+			->getMock();
         $leavePeriodService->expects($this->exactly(2))
                 ->method('getCurrentLeavePeriod')
                 ->will($this->returnValue($leavePeriod));
@@ -270,7 +292,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         // Test handling of exceptions
         // Replace LeaveTypeService with mock that throws an exception
-        $leaveTypeService = $this->getMock('LeaveTypeService', array('getLeaveTypeList'));
+        $leaveTypeService = $this->getMockBuilder('LeaveTypeService')
+			->setMethods( array('getLeaveTypeList'))
+			->getMock();
         $leaveTypeService->expects($this->once())
                 ->method('getLeaveTypeList')
                 ->will($this->throwException(new LeaveServiceException()));
@@ -289,7 +313,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set4');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getOverlappingLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getOverlappingLeave'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('getOverlappingLeave')
                 ->with('2010-02-03', '2010-02-05', 12, '00:00:00','00:00:00', 8)
@@ -306,7 +332,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set4');
         $leave = $leaveList[0];
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('saveLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('saveLeave'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('saveLeave')
                 ->with($leave)
@@ -321,7 +349,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set4');
         $leave = $leaveList[0];
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('readLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('readLeave'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('readLeave')
                 ->with($leave->leave_id)
@@ -362,7 +392,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
     public function xtestGetLeaveRequestStatus() {
 
         $leaveDate = '2010-03-29';
-        $holidayService = $this->getMock('HolidayService', array('readHolidayByDate'));
+        $holidayService = $this->getMockBuilder('HolidayService')
+			->setMethods( array('readHolidayByDate'))
+			->getMock();
         $holidayService->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with($leaveDate)
@@ -373,7 +405,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals($status, Leave::LEAVE_STATUS_LEAVE_PENDING_APPROVAL);
 
-        $holidayService = $this->getMock('HolidayService', array('readHolidayByDate'));
+        $holidayService = $this->getMockBuilder('HolidayService')
+			->setMethods( array('readHolidayByDate'))
+			->getMock();
         $holidayService->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with($leaveDate)
@@ -385,7 +419,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($status, Leave::LEAVE_STATUS_LEAVE_HOLIDAY);
 
         // Test exception case
-        $holidayService = $this->getMock('HolidayService', array('readHolidayByDate'));
+        $holidayService = $this->getMockBuilder('HolidayService')
+			->setMethods( array('readHolidayByDate'))
+			->getMock();
         $holidayService->expects($this->once())
                 ->method('readHolidayByDate')
                 ->with($leaveDate)
@@ -488,7 +524,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->leaveRequestService->setLeaveEntitlementService($leaveEntitlementService);
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getNumOfAvaliableLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getNumOfAvaliableLeave'))
+			->getMock();
 
         $leaveRequestDao->expects($this->once())
                 ->method('getNumOfAvaliableLeave')
@@ -574,7 +612,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $this->leaveRequestService->setLeaveEntitlementService($leaveEntitlementService);
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getNumOfAvaliableLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getNumOfAvaliableLeave'))
+			->getMock();
 
         $leaveRequestDao->expects($this->any())
                 ->method('getNumOfAvaliableLeave')
@@ -621,7 +661,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $leaveList = TestDataService::loadObjectList('Leave', $this->fixture, 'set4');
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getTotalLeaveDuration'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getTotalLeaveDuration'))
+			->getMock();
         $leaveRequestDao->expects($this->once())
                 ->method('getTotalLeaveDuration')
                 ->will($this->returnValue(10));
@@ -645,7 +687,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         
         $changeType = 'change_leave_request';
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('fetchLeave'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('fetchLeave'))
+			->getMock();
 
         $leaveRequestDao->expects($this->any())
                 ->method('fetchLeave')
@@ -656,7 +700,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $mockLeaveStateManager = new MockLeaveStateManager();
         $this->leaveRequestService->setLeaveStateManager($mockLeaveStateManager);
 
-        $leaveNotificationService = $this->getMock('LeaveNotificationService', array('approve', 'cancel', 'reject', 'cancelEmployee'));
+        $leaveNotificationService = $this->getMockBuilder('LeaveNotificationService')
+			->setMethods( array('approve', 'cancel', 'reject', 'cancelEmployee'))
+			->getMock();
         $this->leaveRequestService->setLeaveNotificationService($leaveNotificationService);
 
         $this->leaveRequestService->changeLeaveStatus($changes, $changeType);
@@ -676,7 +722,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
 
         $changeType = 'change_leave';
 
-        $leaveRequestDao = $this->getMock('LeaveRequestDao', array('getLeaveById'));
+        $leaveRequestDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getLeaveById'))
+			->getMock();
 
         $leaveRequestDao->expects($this->any())
                 ->method('getLeaveById')
@@ -687,7 +735,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         $mockLeaveStateManager = new MockLeaveStateManager();
         $this->leaveRequestService->setLeaveStateManager($mockLeaveStateManager);
 
-        $leaveNotificationService = $this->getMock('LeaveNotificationService', array('approve', 'cancel', 'reject', 'cancelEmployee'));
+        $leaveNotificationService = $this->getMockBuilder('LeaveNotificationService')
+			->setMethods( array('approve', 'cancel', 'reject', 'cancelEmployee'))
+			->getMock();
         $this->leaveRequestService->setLeaveNotificationService($leaveNotificationService);
 
         $this->leaveRequestService->changeLeaveStatus($changes, $changeType);
@@ -710,7 +760,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function xtestGetLeaveRequestSearchResultAsArray() {
 
-        $mockDao = $this->getMock('LeaveRequestDao', array('getLeaveRequestSearchResultAsArray'));
+        $mockDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getLeaveRequestSearchResultAsArray'))
+			->getMock();
         $mockDao->expects($this->any())
                 ->method('getLeaveRequestSearchResultAsArray')
                 ->will($this->returnValue(array('em_fist_name'=>'employee1')));
@@ -728,7 +780,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function xgetDetailedLeaveRequestSearchResultAsArray() {
 
-        $mockDao = $this->getMock('LeaveRequestDao', array('getDetailedLeaveRequestSearchResultAsArray'));
+        $mockDao = $this->getMockBuilder('LeaveRequestDao')
+			->setMethods( array('getDetailedLeaveRequestSearchResultAsArray'))
+			->getMock();
         $mockDao->expects($this->any())
                 ->method('getDetailedLeaveRequestSearchResultAsArray')
                 ->will($this->returnValue(array('em_fist_name'=>'employee1')));
@@ -818,7 +872,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetLeaveRequestActionsStatusDiffer() {
         $loggedInEmpNumber = 4;
 
-        $leave = $this->getMock('LeaveRequest', array('isStatusDiffer'));
+        $leave = $this->getMockBuilder('LeaveRequest')
+			->setMethods( array('isStatusDiffer'))
+			->getMock();
         $leave->expects($this->once())
               ->method('isStatusDiffer')
               ->will($this->returnValue(true));
@@ -840,7 +896,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
             'resulting_state' => 'CANCELLED','roles_to_notify' => '','priority' => 0));           
         $actions = array($cancelAction);
         
-        $userManager = $this->getMock('BasicUserRoleManager', array('getAllowedActions'));
+        $userManager = $this->getMockBuilder('BasicUserRoleManager')
+			->setMethods( array('getAllowedActions'))
+			->getMock();
         $userManager->expects($this->any())
                     ->method('getAllowedActions')
                     ->with(WorkflowStateMachine::FLOW_LEAVE, $leave->getTextLeaveStatus(), 
@@ -872,7 +930,9 @@ class LeaveRequestServiceTest extends PHPUnit_Framework_TestCase {
         
         $actions = array($approveAction, $cancelAction, $rejectAction);
         
-        $userManager = $this->getMock('BasicUserRoleManager', array('getAllowedActions'));
+        $userManager = $this->getMockBuilder('BasicUserRoleManager')
+			->setMethods( array('getAllowedActions'))
+			->getMock();
         $userManager->expects($this->any())
                     ->method('getAllowedActions')
                     ->with(WorkflowStateMachine::FLOW_LEAVE, $leave->getTextLeaveStatus(), 

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveTypeServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/LeaveTypeServiceTest.php
@@ -44,7 +44,9 @@
 
         $leaveTypeList = TestDataService::loadObjectList('LeaveType', $this->fixture, 'set1');
 
-        $leaveTypeDao = $this->getMock('LeaveTypeDao', array('getLeaveTypeList'));
+        $leaveTypeDao = $this->getMockBuilder('LeaveTypeDao')
+			->setMethods( array('getLeaveTypeList'))
+			->getMock();
         $leaveTypeDao->expects($this->once())
                      ->method('getLeaveTypeList')
                      ->will($this->returnValue($leaveTypeList));
@@ -64,7 +66,9 @@
 
         $leaveTypeList = TestDataService::loadObjectList('LeaveType', $this->fixture, 'set1');
 
-        $leaveTypeDao = $this->getMock('LeaveTypeDao', array('getLeaveTypeList'));
+        $leaveTypeDao = $this->getMockBuilder('LeaveTypeDao')
+			->setMethods( array('getLeaveTypeList'))
+			->getMock();
         $leaveTypeDao->expects($this->once())
                      ->method('getLeaveTypeList')
                      ->with($this->equalTo(2))
@@ -87,7 +91,9 @@
         $leaveTypeList = TestDataService::loadObjectList('LeaveType', $this->fixture, 'set1');
         $leaveType = $leaveTypeList[0];
 
-        $leaveTypeDao = $this->getMock('LeaveTypeDao', array('saveLeaveType'));
+        $leaveTypeDao = $this->getMockBuilder('LeaveTypeDao')
+			->setMethods( array('saveLeaveType'))
+			->getMock();
         $leaveTypeDao->expects($this->once())
                      ->method('saveLeaveType')
                      ->with($leaveType)
@@ -106,7 +112,9 @@
         $leaveTypeList = TestDataService::loadObjectList('LeaveType', $this->fixture, 'set1');
         $leaveType = $leaveTypeList[0];
 
-        $leaveTypeDao = $this->getMock('LeaveTypeDao', array('readLeaveType'));
+        $leaveTypeDao = $this->getMockBuilder('LeaveTypeDao')
+			->setMethods( array('readLeaveType'))
+			->getMock();
         $leaveTypeDao->expects($this->once())
                      ->method('readLeaveType')
                      ->with('LTY001')

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/WorkScheduleServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/WorkScheduleServiceTest.php
@@ -38,7 +38,9 @@ class WorkScheduleServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testGetWorkScheduleNotDefined() {
         
-        $mockService = $this->getMock('LeaveConfigurationService', array('getWorkScheduleImplementation'));
+        $mockService = $this->getMockBuilder('LeaveConfigurationService')
+			->setMethods( array('getWorkScheduleImplementation'))
+			->getMock();
         $mockService->expects($this->once())
                     ->method('getWorkScheduleImplementation')
                     ->will($this->returnValue(NULL)); 
@@ -58,7 +60,9 @@ class WorkScheduleServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testGetWorkScheduleClassNotFound() {
         
-        $mockService = $this->getMock('LeaveConfigurationService', array('getWorkScheduleImplementation'));
+        $mockService = $this->getMockBuilder('LeaveConfigurationService')
+			->setMethods( array('getWorkScheduleImplementation'))
+			->getMock();
         $mockService->expects($this->once())
                     ->method('getWorkScheduleImplementation')
                     ->will($this->returnValue('xYzNotAvailable')); 
@@ -78,7 +82,9 @@ class WorkScheduleServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testGetWorkScheduleInvalidClass() {
         
-        $mockService = $this->getMock('LeaveConfigurationService', array('getWorkScheduleImplementation'));
+        $mockService = $this->getMockBuilder('LeaveConfigurationService')
+			->setMethods( array('getWorkScheduleImplementation'))
+			->getMock();
         $mockService->expects($this->once())
                     ->method('getWorkScheduleImplementation')
                     ->will($this->returnValue('TestWorkScheduleInvalidClass')); 
@@ -98,7 +104,9 @@ class WorkScheduleServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testGetWorkScheduleClassExceptionInConstructor() {
         
-        $mockService = $this->getMock('LeaveConfigurationService', array('getWorkScheduleImplementation'));
+        $mockService = $this->getMockBuilder('LeaveConfigurationService')
+			->setMethods( array('getWorkScheduleImplementation'))
+			->getMock();
         $mockService->expects($this->once())
                     ->method('getWorkScheduleImplementation')
                     ->will($this->returnValue('TestWorkScheduleInvalidClassExceptionInConstructor')); 
@@ -115,7 +123,9 @@ class WorkScheduleServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testGetWorkSchedule() {
         
-        $mockService = $this->getMock('LeaveConfigurationService', array('getWorkScheduleImplementation'));
+        $mockService = $this->getMockBuilder('LeaveConfigurationService')
+			->setMethods( array('getWorkScheduleImplementation'))
+			->getMock();
         $mockService->expects($this->once())
                     ->method('getWorkScheduleImplementation')
                     ->will($this->returnValue('TestWorkScheduleValidClass')); 

--- a/symfony/plugins/orangehrmLeavePlugin/test/model/service/WorkWeekServiceTest.php
+++ b/symfony/plugins/orangehrmLeavePlugin/test/model/service/WorkWeekServiceTest.php
@@ -53,7 +53,9 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
       $workWeekList   = TestDataService::loadObjectList('WorkWeek', $this->fixture, 'WorkWeek');
       $workWeek       = $workWeekList[0];
 
-      $workWeekDao = $this->getMock('WorkWeekDao', array('saveWorkWeek'));
+      $workWeekDao = $this->getMockBuilder('WorkWeekDao')
+			->setMethods( array('saveWorkWeek'))
+			->getMock();
       $workWeekDao->expects($this->once())
                   ->method('saveWorkWeek')
                   ->with($workWeek)
@@ -71,7 +73,9 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
 
       $workWeekList   = TestDataService::loadObjectList('WorkWeek', $this->fixture, 'WorkWeek');
       
-      $workWeekDao = $this->getMock('WorkWeekDao', array('getWorkWeekList'));
+      $workWeekDao = $this->getMockBuilder('WorkWeekDao')
+			->setMethods( array('getWorkWeekList'))
+			->getMock();
       $workWeekDao->expects($this->once())
                   ->method('getWorkWeekList')
                   ->will($this->returnValue($workWeekList));
@@ -92,7 +96,9 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
 
       $workWeekList   = TestDataService::loadObjectList('WorkWeek', $this->fixture, 'WorkWeek');
 
-      $workWeekDao = $this->getMock('WorkWeekDao', array('readWorkWeek'));
+      $workWeekDao = $this->getMockBuilder('WorkWeekDao')
+			->setMethods( array('readWorkWeek'))
+			->getMock();
       $workWeekDao->expects($this->once())
                   ->method('readWorkWeek')
                   ->with(1)
@@ -110,7 +116,9 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
 
     public function testReadWorkWeekReturnsNullInDao() {
 
-      $workWeekDao = $this->getMock('WorkWeekDao', array('readWorkWeek'));
+      $workWeekDao = $this->getMockBuilder('WorkWeekDao')
+			->setMethods( array('readWorkWeek'))
+			->getMock();
       $workWeekDao->expects($this->once())
                   ->method('readWorkWeek')
                   ->with(8)
@@ -127,7 +135,9 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
     
     public function testIsWeekend() {
 
-      $workWeekDao = $this->getMock('WorkWeekDao', array('isWeekend'));
+      $workWeekDao = $this->getMockBuilder('WorkWeekDao')
+			->setMethods( array('isWeekend'))
+			->getMock();
       $workWeekDao->expects($this->once())
                   ->method('isWeekend')
                   ->with(1, true)
@@ -142,7 +152,9 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
     
     public function testDeleteWorkWeek() {
 
-      $workWeekDao = $this->getMock('WorkWeekDao', array('deleteWorkWeek'));
+      $workWeekDao = $this->getMockBuilder('WorkWeekDao')
+			->setMethods( array('deleteWorkWeek'))
+			->getMock();
       $workWeekDao->expects($this->once())
                   ->method('deleteWorkWeek')
                   ->with(array(1,2))
@@ -161,12 +173,17 @@ class WorkWeekServiceTest extends PHPUnit_Framework_TestCase
         $workWeek = new WorkWeek();
         $workWeek->setId(2);
         
-        $recordsMock = $this->getMock('Doctrine_Collection', array('getFirst'), array('WorkWeek'));
+        $recordsMock = $this->getMockBuilder('Doctrine_Collection')
+			->setMethods( array('getFirst'))
+            ->setConstructorArgs(array('WorkWeek'))
+			->getMock();
         $recordsMock->expects($this->exactly(3))
                 ->method('getFirst')
                 ->will($this->onConsecutiveCalls($defaultWorkWeek, $defaultWorkWeek, $workWeek));
         
-        $workWeekDaoMock = $this->getMock('WorkWeekDao', array('searchWorkWeek'));
+        $workWeekDaoMock = $this->getMockBuilder('WorkWeekDao')
+			->setMethods(array('searchWorkWeek'))
+			->getMock();
         $workWeekDaoMock->expects($this->any())
                 ->method('searchWorkWeek')
                 ->will($this->returnValue($recordsMock));

--- a/symfony/plugins/orangehrmOpenidAuthenticationPlugin/test/model/service/AuthenticationProviderServiceTest.php
+++ b/symfony/plugins/orangehrmOpenidAuthenticationPlugin/test/model/service/AuthenticationProviderServiceTest.php
@@ -43,7 +43,7 @@ class AuthenticationProviderServiceTest extends PHPUnit_Framework_TestCase {
         $authProvider->setDeveloperKey('Test_developer_key');
 
 
-        $mockDao = $this->getMock('AuthProviderExtraDetailsDao');
+        $mockDao = $this->getMockBuilder('AuthProviderExtraDetailsDao')->getMock();
         $mockDao->expects($this->once())
                 ->method('getAuthProviderDetailsByProviderId')
                 ->with(2)
@@ -60,7 +60,7 @@ class AuthenticationProviderServiceTest extends PHPUnit_Framework_TestCase {
         $authProvider->setProviderId(3);
         $authProvider->setProviderType(1);
 
-        $mockDao = $this->getMock('AuthProviderExtraDetailsDao');
+        $mockDao = $this->getMockBuilder('AuthProviderExtraDetailsDao')->getMock();
         $mockDao->expects($this->once())
                 ->method('saveAuthProviderExtraDetails')
                 ->with($authProvider)
@@ -80,7 +80,7 @@ class AuthenticationProviderServiceTest extends PHPUnit_Framework_TestCase {
         $authProvider->setClientSecret('Test_secret_4');
         $authProvider->setDeveloperKey('Test_developer_key');
         
-        $mockDao = $this->getMock('AuthProviderExtraDetailsDao');
+        $mockDao = $this->getMockBuilder('AuthProviderExtraDetailsDao')->getMock();
         $mockDao->expects($this->once())
                 ->method('saveAuthProviderExtraDetails')
                 ->with($authProvider)

--- a/symfony/plugins/orangehrmOpenidAuthenticationPlugin/test/model/service/OpenIdProviderServiceTest.php
+++ b/symfony/plugins/orangehrmOpenidAuthenticationPlugin/test/model/service/OpenIdProviderServiceTest.php
@@ -42,7 +42,9 @@ class OpenIdProviderServiceTest extends PHPUnit_Framework_TestCase {
         $openIdProvider->setProviderUrl('http://new.com/id');
         $openIdProvider->setStatus(1);
         
-        $openIdProviderDaoMock = $this->getMock('OpenIdProviderDao', array('saveOpenIdProvider'));
+        $openIdProviderDaoMock = $this->getMockBuilder('OpenIdProviderDao')
+			->setMethods( array('saveOpenIdProvider'))
+			->getMock();
 
         $openIdProviderDaoMock->expects($this->once())
                 ->method('saveOpenIdProvider')
@@ -82,7 +84,9 @@ class OpenIdProviderServiceTest extends PHPUnit_Framework_TestCase {
         $openIdProviderList[0] =$openIdProvider1;
         $openIdProviderList[1] =$openIdProvider2;
         
-        $openIdProviderDaoMock = $this->getMock('OpenIdProviderDao', array('listOpenIdProviders'));
+        $openIdProviderDaoMock = $this->getMockBuilder('OpenIdProviderDao')
+			->setMethods( array('listOpenIdProviders'))
+			->getMock();
 
         $openIdProviderDaoMock->expects($this->once())
                 ->method('listOpenIdProviders')
@@ -110,7 +114,9 @@ class OpenIdProviderServiceTest extends PHPUnit_Framework_TestCase {
         
          
         
-        $openIdProviderDaoMock = $this->getMock('OpenIdProviderDao', array('removeOpenIdProvider','getOpenIdProvider'));
+        $openIdProviderDaoMock = $this->getMockBuilder('OpenIdProviderDao')
+			->setMethods( array('removeOpenIdProvider','getOpenIdProvider'))
+			->getMock();
 
         $openIdProviderDaoMock->expects($this->once())
                 ->method('removeOpenIdProvider')
@@ -139,7 +145,9 @@ class OpenIdProviderServiceTest extends PHPUnit_Framework_TestCase {
         $openIdProvider->setProviderUrl('https://google.com/o/8/');
         $openIdProvider->setStatus(1);
         
-        $openIdProviderDaoMock = $this->getMock('OpenIdProviderDao', array('getOpenIdProvider'));
+        $openIdProviderDaoMock = $this->getMockBuilder('OpenIdProviderDao')
+			->setMethods( array('getOpenIdProvider'))
+			->getMock();
 
         $openIdProviderDaoMock->expects($this->once())
                 ->method('getOpenIdProvider')

--- a/symfony/plugins/orangehrmPerformancePlugin/test/model/service/KpiServiceTest.php
+++ b/symfony/plugins/orangehrmPerformancePlugin/test/model/service/KpiServiceTest.php
@@ -20,7 +20,7 @@ class KpiServiceTest extends PHPUnit_Framework_TestCase {
     public function testSaveKpi() {
 
         $kpi360 = new Kpi();
-        $daoMock = $this->getMock("KpiDao", array("saveKpi"));
+        $daoMock = $this->getMockBuilder("KpiDao")->setMethods(array("saveKpi"))->getMock();
         $daoMock->expects($this->any())
                 ->method('saveKpi')
                 ->will($this->returnValue($kpi360));
@@ -35,7 +35,7 @@ class KpiServiceTest extends PHPUnit_Framework_TestCase {
     public function testSearchKpi1() {
 
         $kpi360 = new Kpi();
-        $daoMock = $this->getMock("KpiDao", array("searchKpi"));
+        $daoMock = $this->getMockBuilder("KpiDao")->setMethods(array("searchKpi"))->getMock();
         $daoMock->expects($this->any())
                 ->method('searchKpi')
                 ->will($this->returnValue(array($kpi360)));
@@ -50,7 +50,7 @@ class KpiServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testDeleteKpi() {
 
-        $daoMock = $this->getMock("KpiDao", array("deleteKpi"));
+        $daoMock = $this->getMockBuilder("KpiDao")->setMethods(array("deleteKpi"))->getMock();
         $daoMock->expects($this->any())
                 ->method('deleteKpi')
                 ->with($this->equalTo(array('1', '2')))
@@ -64,7 +64,7 @@ class KpiServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testSearchKpi() {
 
-        $daoMock = $this->getMock("KpiDao", array("searchKpi"));
+        $daoMock = $this->getMockBuilder("KpiDao")->setMethods(array("searchKpi"))->getMock();
         $daoMock->expects($this->any())
                 ->method('searchKpi')
                 ->will($this->returnValue(array(1)));
@@ -76,7 +76,7 @@ class KpiServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testSearchKpiByJobTitle(){
-        $daoMock = $this->getMock("KpiDao", array("searchKpiByJobTitle"));
+        $daoMock = $this->getMockBuilder("KpiDao")->setMethods(array("searchKpiByJobTitle"))->getMock();
         $daoMock->expects($this->any())
                 ->method('searchKpiByJobTitle')
                 ->will($this->returnValue(array(1)));

--- a/symfony/plugins/orangehrmPerformancePlugin/test/model/service/PerforamanceReviewServiceTest.php
+++ b/symfony/plugins/orangehrmPerformancePlugin/test/model/service/PerforamanceReviewServiceTest.php
@@ -19,7 +19,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
     public function testSaveReview() {
 
         $review = new PerformanceReview();
-        $daoMock = $this->getMock("PerformanceReviewDao", array("saveReview"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("saveReview"))->getMock();
         $daoMock->expects($this->any())
                 ->method('saveReview')
                 ->will($this->returnValue($review));
@@ -34,7 +34,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
     public function testSearchReview() {
 
         $review = new PerformanceReview();
-        $daoMock = $this->getMock("PerformanceReviewDao", array("searchReview"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("searchReview"))->getMock();
         $daoMock->expects($this->any())
                 ->method('searchReview')
                 ->will($this->returnValue(array($review)));
@@ -48,7 +48,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testDeleteReview() {
 
-        $daoMock = $this->getMock("PerformanceReviewDao", array("deleteReview"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("deleteReview"))->getMock();
         $daoMock->expects($this->any())
                 ->method('deleteReview')
                 ->will($this->returnValue(true));
@@ -62,7 +62,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testDeleteReviewers() {
 
-        $daoMock = $this->getMock("PerformanceReviewDao", array("deleteReviewersByReviewId"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("deleteReviewersByReviewId"))->getMock();
         $daoMock->expects($this->any())
                 ->method('deleteReviewersByReviewId')
                 ->will($this->returnValue(true));
@@ -75,7 +75,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testSearchReviewRating() {
         $array = array(0 => 1);
-        $daoMock = $this->getMock("PerformanceReviewDao", array("searchRating"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("searchRating"))->getMock();
         $daoMock->expects($this->any())
                 ->method('searchRating')
                 ->will($this->returnValue(array(1)));
@@ -88,7 +88,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testGetReviewRating() {
         $array = array(0 => 1);
-        $daoMock = $this->getMock("PerformanceReviewDao", array("searchRating"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("searchRating"))->getMock();
         $daoMock->expects($this->any())
                 ->method('searchRating')
                 ->will($this->returnValue(array(1)));
@@ -101,7 +101,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testGetReviwerEmployeeList() {
         $array = array(0 => 1);
-        $daoMock = $this->getMock("PerformanceReviewDao", array("getReviwerEmployeeList"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("getReviwerEmployeeList"))->getMock();
         $daoMock->expects($this->any())
                 ->method('getReviwerEmployeeList')
                 ->will($this->returnValue(array(1)));
@@ -116,7 +116,7 @@ class PerforamanceReviewServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testGetCountReviewList() {
         $serachParams['limit'] = null;
-        $daoMock = $this->getMock("PerformanceReviewDao", array("getCountReviewList"));
+        $daoMock = $this->getMockBuilder("PerformanceReviewDao")->setMethods(array("getCountReviewList"))->getMock();
         $daoMock->expects($this->any())
                 ->method('getCountReviewList')
                 ->will($this->returnValue(array(1)));

--- a/symfony/plugins/orangehrmPerformanceTrackerPlugin/test/model/service/PerformanceTrackerServiceTest.php
+++ b/symfony/plugins/orangehrmPerformanceTrackerPlugin/test/model/service/PerformanceTrackerServiceTest.php
@@ -37,7 +37,7 @@ class PerformanceTrackerServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testGetSetPerformanceTrackerDao() {
-        $mockDao = $this->getMock('PerformanceTrackerDao');
+        $mockDao = $this->getMockBuilder('PerformanceTrackerDao')->getMock();
         
         $this->performanceTrackerService->setPerformanceTrackDao($mockDao);
         $this->assertEquals($mockDao, $this->performanceTrackerService->getPerformanceTrackDao());

--- a/symfony/plugins/orangehrmPimPlugin/test/model/dao/EmployeeDaoTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/model/dao/EmployeeDaoTest.php
@@ -710,7 +710,9 @@ class EmployeeDaoTest extends PHPUnit_Framework_TestCase {
 
     public function xtestSaveEmployeePicture() {
 
-        $mockPicture = $this->getMock('EmpPicture', array('save'));
+        $mockPicture = $this->getMockBuilder('EmpPicture')
+			->setMethods( array('save'))
+			->getMock();
         $mockPicture->expects($this->once())
                 ->method('save');
         $result = $this->employeeDao->saveEmployeePicture($mockPicture);
@@ -724,7 +726,9 @@ class EmployeeDaoTest extends PHPUnit_Framework_TestCase {
      */
     public function xtestSaveEmployeePictureException() {
 
-        $mockPicture = $this->getMock('EmpPicture', array('save'));
+        $mockPicture = $this->getMockBuilder('EmpPicture')
+			->setMethods( array('save'))
+			->getMock();
         $mockPicture->expects($this->once())
                 ->method('save')
                 ->will($this->throwException(new DaoException()));

--- a/symfony/plugins/orangehrmPimPlugin/test/model/dao/EmployeeDaoTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/model/dao/EmployeeDaoTest.php
@@ -1038,7 +1038,7 @@ class EmployeeDaoTest extends PHPUnit_Framework_TestCase {
      */
     public function testSaveEmployeeSalaryException() {
         
-        $salary = $this->getMock('EmployeeSalary', array('save'));
+        $salary = $this->getMockBuilder('EmployeeSalary')->setMethods(array('save'))->getMock();
         $salary->expects($this->once())
                 ->method('save')
                 ->will($this->throwException(new Exception()));

--- a/symfony/plugins/orangehrmPimPlugin/test/model/service/CustomFieldConfigurationServiceTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/model/service/CustomFieldConfigurationServiceTest.php
@@ -30,7 +30,7 @@ class CustomFieldsServiceTest extends PHPUnit_Framework_TestCase {
          $customFields->setType($v['type']);
          $customFields->setExtraData($v['extra_data']);
 
-         $this->customFieldsDao  =	$this->getMock('CustomFieldsDao');
+         $this->customFieldsDao  =	$this->getMockBuilder('CustomFieldsDao')->getMock();
          $this->customFieldsDao->expects($this->once())
             ->method('saveCustomField')
             ->will($this->returnValue(true));
@@ -48,7 +48,7 @@ class CustomFieldsServiceTest extends PHPUnit_Framework_TestCase {
       $customFieldsDao = new CustomFieldConfigurationDao();
       $list = $customFieldsDao->getCustomFieldList();
 
-      $this->customFieldsDao  =	$this->getMock('CustomFieldsDao');
+      $this->customFieldsDao  =	$this->getMockBuilder('CustomFieldsDao')->getMock();
       $this->customFieldsDao->expects($this->once())
          ->method('getCustomFieldList')
          ->will($this->returnValue($list));
@@ -68,7 +68,7 @@ class CustomFieldsServiceTest extends PHPUnit_Framework_TestCase {
          $customFields->setType($v['type']);
          $customFields->setExtraData($v['extra_data']);
 
-         $this->customFieldsDao  =	$this->getMock('CustomFieldsDao');
+         $this->customFieldsDao  =	$this->getMockBuilder('CustomFieldsDao')->getMock();
          $this->customFieldsDao->expects($this->once())
                ->method('readCustomField')
                ->will($this->returnValue($customFields));
@@ -83,7 +83,7 @@ class CustomFieldsServiceTest extends PHPUnit_Framework_TestCase {
     */
    public function testDeleteCustomField() {
       foreach($this->testCases['CustomFields'] as $k => $v) {
-         $this->customFieldsDao  =	$this->getMock('CustomFieldsDao');
+         $this->customFieldsDao  =	$this->getMockBuilder('CustomFieldsDao')->getMock();
          $this->customFieldsDao->expects($this->once())
                ->method('deleteCustomField')
                ->will($this->returnValue(true));

--- a/symfony/plugins/orangehrmPimPlugin/test/model/service/EmployeeServiceTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/model/service/EmployeeServiceTest.php
@@ -37,7 +37,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     }
     
     public function testGetSetEmployeeDao() {
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
                 
         $this->employeeService->setEmployeeDao($mockDao);
         $this->assertEquals($mockDao, $this->employeeService->getEmployeeDao());        
@@ -52,7 +52,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $employee->setLastName($v['lastName']);
             $employee->setFirstName($v['firstName']);
 
-            $employeeDao = $this->getMock('EmployeeDao');
+            $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
             $employeeDao->expects($this->once())
                     ->method('saveEmployee')
                     ->will($this->returnValue($employee));
@@ -73,7 +73,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $employee->setFirstName('First Name');
         $employee->setEmpNumber($empNumber);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmployee')
              ->with($empNumber)
@@ -93,7 +93,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testSaveEmployeePicture() {
         
-        $this->employeeDao = $this->getMock('EmployeeDao');
+        $this->employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $this->employeeDao->expects($this->once())
                 ->method('saveEmployeePicture')
                 ->will($this->returnValue(new EmpPicture()));
@@ -122,7 +122,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testReadEmployeePicture() {
         foreach ($this->testCase['Employee'] as $k => $v) {
-            $this->employeeDao = $this->getMock('EmployeeDao');
+            $this->employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
             $this->employeeDao->expects($this->once())
                     ->method('readEmployeePicture')
                     ->will($this->returnValue(new EmpPicture()));
@@ -138,7 +138,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetPicture() {
         $picture = 'askd;sadjf';
         $empNumber = 121;
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeePicture')
                  ->with($empNumber)
@@ -156,7 +156,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testDeletePhoto() {
         foreach ($this->testCase['Employee'] as $k => $v) {
-            $this->employeeDao = $this->getMock('EmployeeDao');
+            $this->employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
             $this->employeeDao->expects($this->once())
                     ->method('deleteEmployeePicture')
                     ->will($this->returnValue(1));
@@ -173,7 +173,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $contactsToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeEmergencyContacts')
                  ->with($empNumber, $contactsToDelete)
@@ -193,7 +193,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $immigrationToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeImmigrationRecords')
                  ->with($empNumber, $immigrationToDelete)
@@ -228,7 +228,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         
         $dependents[1] = $dependent;
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeDependents')
                  ->with($empNumber)
@@ -248,7 +248,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeDependents')
                  ->with($empNumber, $entriesToDelete)
@@ -267,7 +267,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     public function testIsSupervisor() {
         $empNumber = 111;
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('isSupervisor')
                  ->with($empNumber)
@@ -292,7 +292,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $experience->setEmployer('ACME Inc');
         $experience->setJobtitle('Manager');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('saveEmployeeWorkExperience')
                  ->with($experience)
@@ -320,7 +320,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         
         $isEss = true;
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeWorkExperienceRecords')
                  ->with($empNumber, $sequence)
@@ -339,7 +339,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeWorkExperienceRecords')
                  ->with($empNumber, $entriesToDelete)
@@ -364,7 +364,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $education->setYear('2000');
         $education->setScore('3.2');       
        
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('saveEmployeeEducation')
                  ->with($education)
@@ -390,7 +390,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $education->setYear('2000');
         $education->setScore('3.2');  
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEducation')
                  ->with(1)
@@ -409,7 +409,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeEducationRecords')
                  ->with($empNumber, $entriesToDelete)
@@ -432,7 +432,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $skill->setSkillId(2);
         $skill->setYearsOfExp(2);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('saveEmployeeSkill')
                  ->with($skill)
@@ -459,7 +459,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         
         $isEss = true;
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeSkills')
                  ->with($empNumber, $skillCode)
@@ -478,7 +478,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeSkills')
                  ->with($empNumber, $entriesToDelete)
@@ -502,7 +502,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $salary->setId($id);
         $salary->setSalaryName('Travel Expenses');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeSalaries')
                  ->with($empNumber, $id)
@@ -519,7 +519,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 1;
         $entriesToDelete = array(1, 2);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeSalaryComponents')
                  ->with($empNumber, $entriesToDelete)
@@ -545,7 +545,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $language->setCompetency(1);
         $language->setComments('no comments'); 
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('saveEmployeeLanguage')
                  ->with($language)
@@ -574,7 +574,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $languageCode = 2;
         $langType = 1;
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeLanguages')
                  ->with($empNumber, $languageCode, $langType)
@@ -593,7 +593,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array(array(1 => 1), array(1 => 2));
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeLanguages')
                  ->with($empNumber, $entriesToDelete)
@@ -616,7 +616,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $license->setLicenseId(2);
         $license->setLicenseNo('199919');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('saveEmployeeLicense')
                  ->with($license)
@@ -641,7 +641,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $license->setLicenseId($licenseCode);
         $license->setLicenseNo('199919');        
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeLicences')
                  ->with($empNumber, $licenseCode)
@@ -660,7 +660,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeLicenses')
                  ->with($empNumber, $entriesToDelete)
@@ -686,7 +686,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $attachments[] = $attachment;
         }             
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeAttachments')
                  ->with($empNumber, $screen)
@@ -697,7 +697,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $result = $this->employeeService->getEmployeeAttachments($empNumber, $screen);
         $this->assertEquals($attachments, $result);              
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeAttachments')
                  ->with($empNumber, $screen)
@@ -720,7 +720,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 111;
         $entriesToDelete = array('1', '2', '4');
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeAttachments')
                  ->with($empNumber, $entriesToDelete)
@@ -731,7 +731,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $result = $this->employeeService->deleteEmployeeAttachments($empNumber, $entriesToDelete);
         $this->assertEquals(2, $result);              
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployeeAttachments')
                  ->with($empNumber, $entriesToDelete)
@@ -762,7 +762,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $attachment = $attachments[0];
         $attachmentId = $attachment->getAttachId();
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeAttachment')
                  ->with($empNumber, $attachmentId)
@@ -773,7 +773,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $result = $this->employeeService->getEmployeeAttachment($empNumber, $attachmentId);
         $this->assertEquals($attachment, $result);              
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeAttachment')
                  ->with($empNumber, $attachmentId)
@@ -803,7 +803,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $employees[] = $employee;
         }             
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeList')
                  ->with($sortField, $orderBy)
@@ -830,7 +830,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $supervisors[] = $employee;
         }             
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getSupervisorList')
                  ->will($this->returnValue($supervisors));
@@ -856,7 +856,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $employees[] = $employee;
         }             
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('searchEmployee')
                  ->with($field, $value)
@@ -876,7 +876,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $count = 212;         
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeCount')
                  ->will($this->returnValue($count));
@@ -902,7 +902,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         
         $jsonStr = json_encode($employees);
 
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                 ->method('getEmployeeListAsJson')
                 ->with($workShift)
@@ -926,13 +926,13 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $employees[] = $employee;
         }             
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getSubordinateList')
                  ->with($supervisorId, true, true)
                  ->will($this->returnValue($employees));
                  
-        $configServiceMock = $this->getMock('ConfigService');
+        $configServiceMock = $this->getMockBuilder('ConfigService')->getMock();
         $configServiceMock->expects($this->once())
              ->method('isSupervisorChainSuported')
              ->will($this->returnValue(true));
@@ -975,7 +975,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($employees, $result);
         
         // If no employee list passed, will get all employees from dao adn filter        
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('getEmployeeList')
                  ->will($this->returnValue($employees));
@@ -998,7 +998,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $employeesToDelete = array('1', '2', '4');
         $numEmployees = count($employeesToDelete);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                  ->method('deleteEmployees')
                  ->with($employeesToDelete)
@@ -1018,7 +1018,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $employeeId = 'E199';
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                 ->method('isExistingEmployeeId')
                 ->with($employeeId)
@@ -1040,7 +1040,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $middle = 'A';
         $last = 'Kennedy';
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
                 ->method('checkForEmployeeWithSameName')
                 ->with($first, $middle, $last)
@@ -1066,7 +1066,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $emergencyContactList = array();
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getEmployeeEmergencyContacts')
@@ -1089,7 +1089,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empPassport = new EmployeeImmigrationRecord();
         $empPassport->setEmpNumber(1);        
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('saveEmployeeImmigrationRecord')
@@ -1108,7 +1108,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testGetEmployeePassport() {
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getEmployeeImmigrationRecords')
@@ -1125,7 +1125,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
      */
     public function testGetEmployeeTaxExemptions() {
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getEmployeeTaxExemptions')
@@ -1145,7 +1145,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empUsTaxExemption = new EmpUsTaxExemption();
         $empUsTaxExemption->setEmpNumber(3);
         
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('saveEmployeeTaxExemptions')
@@ -1167,7 +1167,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $reportToSupervisorList = TestDataService::loadObjectList('ReportTo', $this->fixture, 'ReportTo');
         $reportToSupervisorList1 = array($reportToSupervisorList[0], $reportToSupervisorList[1]);
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getImmediateSupervisors')
@@ -1189,7 +1189,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $reportToSubordinateList = TestDataService::loadObjectList('ReportTo', $this->fixture, 'ReportTo');
         $reportToSubordinateListList1 = array($reportToSubordinateList[2], $reportToSubordinateList[3]);
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getSubordinateListForEmployee')
@@ -1214,7 +1214,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $reportToObjectList = TestDataService::loadObjectList('ReportTo', $this->fixture, 'ReportTo');
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getReportToObject')
@@ -1238,7 +1238,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $supOrSubListToDelete = array("4 3 4");
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('deleteReportToObject')
@@ -1260,7 +1260,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $membershipDetailList = TestDataService::loadObjectList('EmployeeMembership', $this->fixture, 'EmployeeMembership');
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getEmployeeMemberships')
@@ -1284,7 +1284,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $membershipDetailList = TestDataService::loadObjectList('EmployeeMembership', $this->fixture, 'EmployeeMembership');
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getEmployeeMemberships')
@@ -1303,7 +1303,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $empNumber = 1;
         $membershipIds = array(1, 2);
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('deleteEmployeeMemberships')
@@ -1326,7 +1326,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
 
         $emergencyContactList = TestDataService::loadObjectList('EmpEmergencyContact', $this->fixture, 'EmpEmergencyContact');
 
-        $employeeDao = $this->getMock('EmployeeDao');
+        $employeeDao = $this->getMockBuilder('EmployeeDao')->getMock();
 
         $employeeDao->expects($this->once())
                 ->method('getEmployeeEmergencyContacts')
@@ -1353,7 +1353,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $employee->setEmpNumber($empNumber);
         $employee->setJoinedDate($joinedDate);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmployee')
              ->with($empNumber)
@@ -1366,7 +1366,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         //$this->assertEquals(9, $yearsOfService);
         
         // Test with non-existant employee
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmployee')
              ->with($empNumber)
@@ -1386,7 +1386,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetEmailList() {
         
         $list = array(0 => array( 'empNo' => 1, 'workEmail' => 'kayla@xample.com', 'othEmail' => 'kayla2@xample.com' ));
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmailList')
              ->will($this->returnValue($list));
@@ -1402,7 +1402,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
         $subUnit = 2;
         $includeTerminatedEmployees = true;
 
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmployeesBySubUnit')
              ->with($subUnit, $includeTerminatedEmployees)
@@ -1427,7 +1427,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
                 
         $list   =   array( $employee1,$employee2);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('searchEmployees')
              ->with($parameterHolder)   
@@ -1442,7 +1442,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetEmployeeIdList(){
         $employeeIdList = array(1, 2, 3);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmployeeIdList')
              ->will($this->returnValue($employeeIdList));
@@ -1461,7 +1461,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             $employeePropertyArray[$employee['empNumber']] = array('empNumber' => $employee['empNumber'], 'firstName' => $employee['firstName'], 
             	'lastName' => $employee['lastName'], 'middleName' => $employee['middleName'], 'employeeId' => $employee['employeeId'] );
         }
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getEmployeePropertyList')
              ->with($properties, 'empNumber', 'ASC')
@@ -1476,7 +1476,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetSubordinateIdListBySupervisorId(){
         $subordinateIdList = array(1, 2, 3);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getSubordinateIdListBySupervisorId')
              ->with(1, true)
@@ -1491,7 +1491,7 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetSupervisorIdListBySubordinateId(){
         $subordinateIdList = array(4, 5);
         
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getSupervisorIdListBySubordinateId')
              ->with(3, true)
@@ -1514,12 +1514,12 @@ class EmployeeServiceTest extends PHPUnit_Framework_TestCase {
             	'lastName' => $employee['lastName'], 'middleName' => $employee['middleName'], 'employeeId' => $employee['employeeId'] );
         }
         
-        $configServiceMock = $this->getMock('ConfigService');
+        $configServiceMock = $this->getMockBuilder('ConfigService')->getMock();
         $configServiceMock->expects($this->once())
              ->method('isSupervisorChainSuported')
              ->will($this->returnValue(true));
              
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
              ->method('getSubordinatePropertyListBySupervisorId')
              ->with(3, $properties, true, 'empNumber', 'ASC')

--- a/symfony/plugins/orangehrmPimPlugin/test/model/service/EmployeeYearsOfServiceTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/model/service/EmployeeYearsOfServiceTest.php
@@ -216,7 +216,9 @@ class EmployeeYearsOfServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetEmployeeYearsOfService() {
         $employee = new Employee();
         $employee->setJoinedDate('2007-06-22');
-        $employeeDao    = $this->getMock('EmployeeDao', array('getEmployee'));
+        $employeeDao    = $this->getMockBuilder('EmployeeDao')
+			->setMethods( array('getEmployee'))
+			->getMock();
         $employeeDao->expects($this->once())
                     ->method('getEmployee')
                     ->will($this->returnValue($employee));

--- a/symfony/plugins/orangehrmPimPlugin/test/model/service/PIMLeftMenuServiceTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/model/service/PIMLeftMenuServiceTest.php
@@ -44,7 +44,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
             array(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array(), array()),
         );
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->exactly(3))
              ->method('getAttribute')
              ->will($this->returnValueMap($getAttributeMap));
@@ -56,7 +56,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
              ->with(PIMLeftMenuService::PIM_LEFTMENU_TAXMENU_ENABLED)
              ->will($this->returnValue(true));
         
-        $mockUserRoleManager = $this->getMock('BasicUserRoleManager');
+        $mockUserRoleManager = $this->getMockBuilder('BasicUserRoleManager')->getMock();
         $mockUserRoleManager->expects($this->any())
              ->method('getDataGroupPermissions')
              ->will($this->returnValue($permission));
@@ -85,7 +85,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
             array(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array(), array()),
         );
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->exactly(3))
              ->method('getAttribute')
              ->will($this->returnValueMap($getAttributeMap));
@@ -107,7 +107,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
             return $permission;
         };
         
-        $mockUserRoleManager = $this->getMock('BasicUserRoleManager');
+        $mockUserRoleManager = $this->getMockBuilder('BasicUserRoleManager')->getMock();
         $mockUserRoleManager->expects($this->any())
              ->method('getDataGroupPermissions')
              ->will($this->returnCallback($dataGroupClosure));
@@ -133,7 +133,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
         unset($clearedCache[$empNumber]);        
         $this->assertEquals(count($clearedCache) + 1, count($cache));
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->once())
              ->method('getAttribute')
              ->with(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array())
@@ -153,7 +153,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
         $cache = array(34 => $allMenuItems, 55 => $allMenuItems);
 
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->once())
              ->method('getAttribute')
              ->with(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array())
@@ -172,7 +172,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
         $cache = array(34 => $allMenuItems, 55 => $allMenuItems, 101 => $allMenuItems);
 
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->once())
              ->method('getAttribute')
              ->with(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array())
@@ -197,7 +197,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
             array(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array(), array()),
         );
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->exactly(3))
              ->method('getAttribute')
              ->will($this->returnValueMap($getAttributeMap));
@@ -209,7 +209,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
              ->with(PIMLeftMenuService::PIM_LEFTMENU_TAXMENU_ENABLED)
              ->will($this->returnValue(true));
         
-        $mockUserRoleManager = $this->getMock('BasicUserRoleManager');
+        $mockUserRoleManager = $this->getMockBuilder('BasicUserRoleManager')->getMock();
         $mockUserRoleManager->expects($this->any())
              ->method('getDataGroupPermissions')
              ->will($this->returnValue($permission));
@@ -232,7 +232,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
             array(PIMLeftMenuService::PIM_LEFTMENU_SESSION_KEY, array(), array()),
         );
         
-        $mocksfUser = $this->getMock('MockSfUser');
+        $mocksfUser = $this->getMockBuilder('MockSfUser')->getMock();
         $mocksfUser->expects($this->exactly(3))
              ->method('getAttribute')
              ->will($this->returnValueMap($getAttributeMap));
@@ -244,7 +244,7 @@ class PIMLeftMenuServiceTest extends PHPUnit_Framework_TestCase {
              ->with(PIMLeftMenuService::PIM_LEFTMENU_TAXMENU_ENABLED)
              ->will($this->returnValue(true));
         
-        $mockUserRoleManager = $this->getMock('BasicUserRoleManager');
+        $mockUserRoleManager = $this->getMockBuilder('BasicUserRoleManager')->getMock();
         $mockUserRoleManager->expects($this->any())
              ->method('getDataGroupPermissions')
              ->will($this->returnValue($permission));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/admin/ApiUserLoginAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/admin/ApiUserLoginAPITest.php
@@ -73,7 +73,9 @@ class ApiUserLoginAPITest extends PHPUnit_Framework_TestCase
 
         $adminUsersList[] = $adminUser;
 
-        $authService = $this->getMock('AuthenticationService',array('setCredentials','getLoggedInUserId'));
+        $authService = $this->getMockBuilder('AuthenticationService')
+            ->setMethods(array('setCredentials','getLoggedInUserId'))
+            ->getMock();
         $authService->expects($this->any())
             ->method('setCredentials')
             ->with($filters['username'],$filters['password'],$additionalData)
@@ -84,28 +86,32 @@ class ApiUserLoginAPITest extends PHPUnit_Framework_TestCase
             ->with()
             ->will($this->returnValue(1));
 
-        $loginService = $this->getMockBuilder('LoginService')->getMock();
-        $loginService->expects($this->any())
+        $systemUserService = $this->getMockBuilder('SystemUserService')
+            ->setMethods(array('getSystemUser'))
+            ->getMock();
+        $systemUserService->expects($this->any())
             ->method('getSystemUser')
             ->with(1)
             ->will($this->returnValue($adminUser));
 
-        $this->usersAPI = $this->getMock('Orangehrm\Rest\Api\Admin\UserLoginAPI',array('getFilterParameters'),array($request));
+        $this->usersAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Admin\UserLoginAPI')
+            ->setMethods(array('getFilterParameters'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->usersAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
 
         $this->usersAPI->setAuthenticationService($authService);
-        $this->usersAPI->setLoginService($loginService);
+        $this->usersAPI->setSystemUserService($systemUserService);
 
         $response = $this->usersAPI->userLogin();
-        $success = $response->getData()['login'];
 
         $user = new User();
         $user->buildUser($adminUser);
-        $mockResponse = new Response( array('login' => true, 'user' => $user->toArray()));
+        $expectedResponse = new Response( array('login' => true, 'user' => $user->toArray()));
 
-        $this->assertEquals(true, $success);
+        $this->assertEquals($expectedResponse->format(), $response->format());
 
     }
 

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/admin/ApiUserLoginAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/admin/ApiUserLoginAPITest.php
@@ -84,7 +84,7 @@ class ApiUserLoginAPITest extends PHPUnit_Framework_TestCase
             ->with()
             ->will($this->returnValue(1));
 
-        $loginService = $this->getMock('LoginService');
+        $loginService = $this->getMockBuilder('LoginService')->getMock();
         $loginService->expects($this->any())
             ->method('getSystemUser')
             ->with(1)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/admin/ApiUsersAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/admin/ApiUsersAPITest.php
@@ -77,7 +77,7 @@ class ApiUsersAPITest extends PHPUnit_Framework_TestCase
 
         $adminUsersList[] = $adminUser;
 
-        $systemUserService = $this->getMock('SystemUserService');
+        $systemUserService = $this->getMockBuilder('SystemUserService')->getMock();
         $systemUserService->expects($this->any())
             ->method('searchSystemUsers')
             ->with($filters)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeaveEntitlementAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeaveEntitlementAPITest.php
@@ -71,7 +71,10 @@ class ApiLeaveEntitlementAPITest extends PHPUnit_Framework_TestCase
         $entitlementsCollection = new Doctrine_Collection('LeaveEntitlement');
         $entitlementsCollection[] = $leaveEntitlement;
 
-        $entitlementApi = $this->getMock('Orangehrm\Rest\Api\Leave\LeaveEntitlementAPI',array('createEntitlement'),array($request));
+        $entitlementApi = $this->getMockBuilder('Orangehrm\Rest\Api\Leave\LeaveEntitlementAPI')
+            ->setMethods(array('createEntitlement'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $entitlementApi->expects($this->once())
             ->method('createEntitlement')
             ->will($this->returnValue($leaveEntitlement));
@@ -129,7 +132,10 @@ class ApiLeaveEntitlementAPITest extends PHPUnit_Framework_TestCase
         $searchParameters->setFromDate('2016-04-20');
         $searchParameters->setToDate('2017-04-20');
 
-        $entitlementApi = $this->getMock('Orangehrm\Rest\Api\Leave\LeaveEntitlementAPI',array('getFilters'),array($request));
+        $entitlementApi = $this->getMockBuilder('Orangehrm\Rest\Api\Leave\LeaveEntitlementAPI')
+            ->setMethods(array('getFilters'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $entitlementApi->expects($this->once())
             ->method('getFilters')
             ->will($this->returnValue($searchParameters));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeaveEntitlementAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeaveEntitlementAPITest.php
@@ -79,7 +79,7 @@ class ApiLeaveEntitlementAPITest extends PHPUnit_Framework_TestCase
 
         $entitlementApi->setRequestParams($requestParams);
 
-        $entitlementService = $this->getMock('LeaveEntitlementService');
+        $entitlementService = $this->getMockBuilder('LeaveEntitlementService')->getMock();
         $entitlementService->expects($this->any())
             ->method('saveLeaveEntitlement')
             ->with($leaveEntitlement)
@@ -136,7 +136,7 @@ class ApiLeaveEntitlementAPITest extends PHPUnit_Framework_TestCase
 
         $entitlementApi->setRequestParams($requestParams);
 
-        $entitlementService = $this->getMock('LeaveEntitlementService');
+        $entitlementService = $this->getMockBuilder('LeaveEntitlementService')->getMock();
         $entitlementService->expects($this->any())
             ->method('searchLeaveEntitlements')
             ->with($searchParameters)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeavePeriodAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeavePeriodAPITest.php
@@ -61,7 +61,7 @@ class ApiLeavePeriodAPITest extends PHPUnit_Framework_TestCase
         $leavePeriodList = array(array('2017-01-01','2018-01-01'),array('2018-01-01','2019-01-01'));
 
 
-        $leavePeriodService = $this->getMock('LeavePeriodService');
+        $leavePeriodService = $this->getMockBuilder('LeavePeriodService')->getMock();
         $leavePeriodService->expects($this->any())
             ->method('getGeneratedLeavePeriodList')
             ->will($this->returnValue($leavePeriodList));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeaveTypeAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/leave/ApiLeaveTypeAPITest.php
@@ -71,7 +71,7 @@ class ApiLeaveTypeAPITest extends PHPUnit_Framework_TestCase
         $typesCollection = new Doctrine_Collection('LeaveType');
         $typesCollection[] = $leaveType;
 
-        $leaveTypeService = $this->getMock('LeaveTypeService');
+        $leaveTypeService = $this->getMockBuilder('LeaveTypeService')->getMock();
         $leaveTypeService->expects($this->any())
             ->method('getLeaveTypeList')
             ->will($this->returnValue($typesCollection));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiCustomFieldAPITest1.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiCustomFieldAPITest1.php
@@ -65,7 +65,7 @@ class ApiCustomFieldAPITest1 extends PHPUnit_Framework_TestCase
 
         $this->employeeCustomFieldAPI->setRequestParams($requestParams);
 
-        $pimCustomFieldService = $this->getMock('CustomFieldConfigurationService');
+        $pimCustomFieldService = $this->getMockBuilder('CustomFieldConfigurationService')->getMock();
         $pimCustomFieldService->expects($this->any())
             ->method('getCustomFieldList')
             ->with(null, 'name', 'ASC')

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeContactDetailAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeContactDetailAPITest.php
@@ -135,7 +135,10 @@ class ApiEmployeeContactDetailAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeContactDetailAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeContactDetailApi',array('filterParameters','validateEmployeeEmails'),array($request));
+        $this->employeeContactDetailAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeContactDetailApi')
+            ->setMethods(array('filterParameters','validateEmployeeEmails'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeContactDetailAPI->expects($this->once())
             ->method('filterParameters')
             ->will($this->returnValue($filters));
@@ -212,7 +215,10 @@ class ApiEmployeeContactDetailAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeContactDetailAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeContactDetailApi',array('filterParameters','validateEmployeeEmails'),array($request));
+        $this->employeeContactDetailAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeContactDetailApi')
+            ->setMethods(array('filterParameters','validateEmployeeEmails'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeContactDetailAPI->expects($this->once())
             ->method('filterParameters')
             ->will($this->returnValue($filters));
@@ -270,7 +276,9 @@ class ApiEmployeeContactDetailAPITest extends PHPUnit_Framework_TestCase
 //
 //         $employeeContactDetailAPI = new EmployeeContactDetailAPI($request);
 //
-//       // $employeeContactDetailAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeContactDetailApi',null,array($request));
+//       // $employeeContactDetailAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeContactDetailApi')
+//              ->setConstructorArgs(array($request))
+//              ->getMock();
 //        $returned = $employeeContactDetailAPI->validateInputs($filters);
 //        $this->assertEquals($returned, true);
 //

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeContactDetailAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeContactDetailAPITest.php
@@ -80,7 +80,7 @@ class ApiEmployeeContactDetailAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeContactDetailAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -145,7 +145,7 @@ class ApiEmployeeContactDetailAPITest extends PHPUnit_Framework_TestCase
             ->with($employee,$employee->getEmpWorkEmail(),$employee->getOtherId())
             ->will($this->returnValue(true));
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with(1)
@@ -222,7 +222,7 @@ class ApiEmployeeContactDetailAPITest extends PHPUnit_Framework_TestCase
             ->with($employee,$employee->getEmpWorkEmail(),$employee->getOtherId())
             ->will($this->returnValue(true));
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with(1)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeCustomFieldAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeCustomFieldAPITest.php
@@ -164,8 +164,10 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $assetResArray[] = $customEntField->toArray();
 
-        $this->employeeCustomFieldAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeCustomFieldAPI',
-            array('getFilterParameters'), array($request));
+        $this->employeeCustomFieldAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeCustomFieldAPI')
+            ->setMethods(array('getFilterParameters'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeCustomFieldAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
@@ -242,8 +244,10 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $assetResArray[] = $customEntField->toArray();
 
-        $this->employeeCustomFieldAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeCustomFieldAPI',
-            array('getFilterParameters'), array($request));
+        $this->employeeCustomFieldAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeCustomFieldAPI')
+            ->setMethods(array('getFilterParameters'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeCustomFieldAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
@@ -319,8 +323,10 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $assetResArray[] = $customEntField->toArray();
 
-        $this->employeeCustomFieldAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeCustomFieldAPI',
-            array('getFilterParameters'), array($request));
+        $this->employeeCustomFieldAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeCustomFieldAPI')
+            ->setMethods(array('getFilterParameters'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeCustomFieldAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeCustomFieldAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeCustomFieldAPITest.php
@@ -72,13 +72,13 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeCustomFieldAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
             ->will($this->returnValue($employee));
 
-        $pimCustomFieldService = $this->getMock('CustomFieldConfigurationService');
+        $pimCustomFieldService = $this->getMockBuilder('CustomFieldConfigurationService')->getMock();
         $pimCustomFieldService->expects($this->any())
             ->method('getCustomFieldList')
             ->with(null,'name','ASC')
@@ -131,7 +131,7 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeCustomFieldAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -141,7 +141,7 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
             ->with($employee)
             ->will($this->returnValue($employee));
 
-        $pimCustomFieldService = $this->getMock('CustomFieldConfigurationService');
+        $pimCustomFieldService = $this->getMockBuilder('CustomFieldConfigurationService')->getMock();
         $pimCustomFieldService->expects($this->any())
             ->method('getCustomField')
             ->with(1)
@@ -209,7 +209,7 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeCustomFieldAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -219,7 +219,7 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
             ->with($employee)
             ->will($this->returnValue($employee));
 
-        $pimCustomFieldService = $this->getMock('CustomFieldConfigurationService');
+        $pimCustomFieldService = $this->getMockBuilder('CustomFieldConfigurationService')->getMock();
         $pimCustomFieldService->expects($this->any())
             ->method('getCustomField')
             ->with(1)
@@ -286,7 +286,7 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeCustomFieldAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -296,7 +296,7 @@ class ApiEmployeeCustomFieldAPITest extends PHPUnit_Framework_TestCase
             ->with($employee)
             ->will($this->returnValue($employee));
 
-        $pimCustomFieldService = $this->getMock('CustomFieldConfigurationService');
+        $pimCustomFieldService = $this->getMockBuilder('CustomFieldConfigurationService')->getMock();
         $pimCustomFieldService->expects($this->any())
             ->method('getCustomField')
             ->with(1)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeDependentAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeDependentAPITest.php
@@ -177,12 +177,17 @@ class ApiEmployeeDependentAPITest extends PHPUnit_Framework_TestCase
         $request = new Request($sfRequest);
 
 
-        $employeeDependantAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeDependentAPI',array('filterParameters','buildEmployeeDependants'),array($request));
+        $employeeDependantAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeDependentAPI')
+            ->setMethods(array('filterParameters','buildEmployeeDependants'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $employeeDependantAPI->expects($this->once())
             ->method('filterParameters')
             ->will($this->returnValue($filters));
 
-        $pimEmployeeService = $this->getMock('EmployeeService',array('deleteEmployeeDependents'));
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')
+            ->setMethods(array('deleteEmployeeDependents'))
+            ->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('deleteEmployeeDependents')
             ->with(1,array(1))

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeDependentAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeDependentAPITest.php
@@ -87,7 +87,7 @@ class ApiEmployeeDependentAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeDependantAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployeeDependents')
             ->with($empNumber)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeDetailAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeDetailAPITest.php
@@ -65,7 +65,7 @@ class ApiEmployeeDetailAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeDetailAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeEducationAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeEducationAPITest.php
@@ -167,7 +167,11 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeEducationAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeEducationAPI',array('getFilterParameters','buildEmployeeEducation'),array($request));
+        $this->employeeEducationAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeEducationAPI')
+                ->setMethods(array('getFilterParameters','buildEmployeeEducation'))
+                ->setConstructorArgs(array($request))
+                ->getMock();
+
         $this->employeeEducationAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
@@ -260,7 +264,11 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeEducationAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeEducationAPI',array('getFilterParameters','buildEmployeeEducation'),array($request));
+        $this->employeeEducationAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeEducationAPI')
+            ->setMethods(array('getFilterParameters','buildEmployeeEducation'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
+
         $this->employeeEducationAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
@@ -349,7 +357,10 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeEducationAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeEducationAPI',array('getFilterParameters','buildEmployeeEducation'),array($request));
+        $this->employeeEducationAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeEducationAPI')
+            ->setMethods(array('getFilterParameters','buildEmployeeEducation'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeEducationAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeEducationAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeEducationAPITest.php
@@ -78,7 +78,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeEducationAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -142,7 +142,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeEducationAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -157,7 +157,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
         $education = new \Education();
         $education->setId(1);
 
-        $pimEducationServiceService = $this->getMock('EducationService');
+        $pimEducationServiceService = $this->getMockBuilder('EducationService')->getMock();
         $pimEducationServiceService->expects($this->any())
             ->method('getEducationById')
             ->with('1')
@@ -225,7 +225,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeEducationAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -249,7 +249,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
         $education = new \Education();
         $education->setId(1);
 
-        $pimEducationServiceService = $this->getMock('EducationService');
+        $pimEducationServiceService = $this->getMockBuilder('EducationService')->getMock();
         $pimEducationServiceService->expects($this->any())
             ->method('getEducationById')
             ->with('1')
@@ -318,7 +318,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeEducationAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -338,7 +338,7 @@ class ApiEmployeeEducationAPITest extends PHPUnit_Framework_TestCase
         $education = new \Education();
         $education->setId(1);
 
-        $pimEducationServiceService = $this->getMock('EducationService');
+        $pimEducationServiceService = $this->getMockBuilder('EducationService')->getMock();
         $pimEducationServiceService->expects($this->any())
             ->method('getEducationById')
             ->with('1')

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeJobDetailAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeJobDetailAPITest.php
@@ -77,7 +77,7 @@ class ApiEmployeeJobDetailAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeJobDetailAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -137,7 +137,7 @@ class ApiEmployeeJobDetailAPITest extends PHPUnit_Framework_TestCase
             ->with($employee,$filters);
 
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with(1)
@@ -198,7 +198,7 @@ class ApiEmployeeJobDetailAPITest extends PHPUnit_Framework_TestCase
             ->with($employee,$filters);
 
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with(1)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeJobDetailAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeJobDetailAPITest.php
@@ -124,7 +124,10 @@ class ApiEmployeeJobDetailAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $employeeJobDetailAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeJobDetailAPI',array('filterParameters','validateInputs','buildEmployeeJobDetails'),array($request));
+        $employeeJobDetailAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeJobDetailAPI')
+            ->setMethods(array('filterParameters','validateInputs','buildEmployeeJobDetails'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $employeeJobDetailAPI->expects($this->once())
             ->method('filterParameters')
             ->will($this->returnValue($filters));
@@ -185,7 +188,10 @@ class ApiEmployeeJobDetailAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $employeeJobDetailAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeJobDetailAPI',array('filterParameters','validateInputs'),array($request));
+        $employeeJobDetailAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeJobDetailAPI')
+            ->setMethods(array('filterParameters','validateInputs', 'buildEmployeeJobDetails'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $employeeJobDetailAPI->expects($this->once())
             ->method('filterParameters')
             ->will($this->returnValue($filters));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeSaveAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeSaveAPITest.php
@@ -62,7 +62,7 @@ class ApiEmployeeSaveAPITest extends PHPUnit_Framework_TestCase
             ->with($filters)
             ->will($this->returnValue($employee));
 
-        $pimEmployeeService = $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('saveEmployee')
             ->with($employee)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeSearchAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeSearchAPITest.php
@@ -62,7 +62,10 @@ class ApiEmployeeSearchAPITest extends PHPUnit_Framework_TestCase
       //  $request->getActionRequest()->setParameter()
         $parameterHolder->setReturnType(\EmployeeSearchParameterHolder::RETURN_TYPE_OBJECT);
 
-        $this->employeeSearchAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeSearchAPI',array('buildSearchParamHolder'),array($request));
+        $this->employeeSearchAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeSearchAPI')
+            ->setMethods(array('buildSearchParamHolder'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeSearchAPI->expects($this->once())
             ->method('buildSearchParamHolder')
             ->will($this->returnValue($parameterHolder));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeSearchAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeSearchAPITest.php
@@ -77,7 +77,7 @@ class ApiEmployeeSearchAPITest extends PHPUnit_Framework_TestCase
         $employeeList = new Doctrine_Collection('Employee');
         $employeeList[] = $employee;
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('searchEmployees')
             ->with($parameterHolder)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeTerminateAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeTerminateAPITest.php
@@ -68,7 +68,10 @@ class ApiEmployeeTerminateAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeTerminateAPi = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeTerminateAPI',array('filterParameters','validateInputs','buildTerminationRecord'),array($request));
+        $this->employeeTerminateAPi = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeTerminateAPI')
+            ->setMethods(array('filterParameters','validateInputs','buildTerminationRecord'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeTerminateAPi->expects($this->once())
             ->method('filterParameters')
             ->will($this->returnValue($filters));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeTerminateAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeTerminateAPITest.php
@@ -83,7 +83,7 @@ class ApiEmployeeTerminateAPITest extends PHPUnit_Framework_TestCase
             ->with($filters)
             ->will($this->returnValue($employeeTerminationRecord));
 
-        $pimEmployeeService = $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with(1)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeWorkExperienceAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeWorkExperienceAPITest.php
@@ -73,7 +73,7 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeWorkExperienceAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -133,7 +133,7 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeWorkExperienceAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -205,7 +205,7 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeWorkExperienceAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)
@@ -282,7 +282,7 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeWorkExperienceAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getEmployee')
             ->with($empNumber)

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeWorkExperienceAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiEmployeeWorkExperienceAPITest.php
@@ -148,7 +148,10 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeWorkExperienceAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeWorkExperienceAPI',array('getFilterParameters','buildEmployeeWorkExperience'),array($request));
+        $this->employeeWorkExperienceAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeWorkExperienceAPI')
+            ->setMethods(array('getFilterParameters','buildEmployeeWorkExperience'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeWorkExperienceAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
@@ -225,7 +228,10 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeWorkExperienceAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeWorkExperienceAPI',array('getFilterParameters','buildEmployeeWorkExperience'),array($request));
+        $this->employeeWorkExperienceAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeWorkExperienceAPI')
+            ->setMethods(array('getFilterParameters','buildEmployeeWorkExperience'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
         $this->employeeWorkExperienceAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));
@@ -302,7 +308,11 @@ class ApiEmployeeWorkExperienceAPITest extends PHPUnit_Framework_TestCase
         $sfRequest = new sfWebRequest($sfEvent);
         $request = new Request($sfRequest);
 
-        $this->employeeWorkExperienceAPI = $this->getMock('Orangehrm\Rest\Api\Pim\EmployeeWorkExperienceAPI',array('getFilterParameters','buildEmployeeWorkExperience'),array($request));
+        $this->employeeWorkExperienceAPI = $this->getMockBuilder('Orangehrm\Rest\Api\Pim\EmployeeWorkExperienceAPI')
+            ->setMethods(array('getFilterParameters','buildEmployeeWorkExperience'))
+            ->setConstructorArgs(array($request))
+            ->getMock();
+
         $this->employeeWorkExperienceAPI->expects($this->once())
             ->method('getFilterParameters')
             ->will($this->returnValue($filters));

--- a/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiSupervisorAPITest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/api/pim/ApiSupervisorAPITest.php
@@ -89,7 +89,7 @@ class ApiSupervisorAPITest extends PHPUnit_Framework_TestCase
 
         $this->employeeSupervisorAPI->setRequestParams($requestParams);
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getImmediateSupervisors')
             ->with($empNumber)
@@ -133,7 +133,7 @@ class ApiSupervisorAPITest extends PHPUnit_Framework_TestCase
         $supervisorsList = new Doctrine_Collection('ReportTo');
         $supervisorsList[] = $empSupervisorTest;
 
-        $pimEmployeeService = $this->getMock('EmployeeService');
+        $pimEmployeeService = $this->getMockBuilder('EmployeeService')->getMock();
         $pimEmployeeService->expects($this->any())
             ->method('getReportToObject')
             ->with(2,1)
@@ -159,7 +159,7 @@ class ApiSupervisorAPITest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($filters));
 
 
-        $reportingMethodConfigService = $this->getMock('ReportingMethodConfigurationService');
+        $reportingMethodConfigService = $this->getMockBuilder('ReportingMethodConfigurationService')->getMock();
         $reportingMethodConfigService->expects($this->any())
             ->method('getReportingMethodByName')
             ->with(null)

--- a/symfony/plugins/orangehrmRESTPlugin/test/model/service/HttpEmployeeServiceTest.php
+++ b/symfony/plugins/orangehrmRESTPlugin/test/model/service/HttpEmployeeServiceTest.php
@@ -43,7 +43,7 @@ class HttpEmployeeServiceTest extends PHPUnit_Framework_TestCase
 
     public function testGetEmployeeDetails(){
 
-        $requestParams = $this->getMock('\Orangehrm\Rest\Http\RequestParams', ['getQueryParam']);
+        $requestParams = $this->getMockBuilder('\Orangehrm\Rest\Http\RequestParams')->setMethods(['getQueryParam'])->getMock();
         $requestParams->expects($this->once())
             ->method('getQueryParam')
             ->with('id')
@@ -56,7 +56,7 @@ class HttpEmployeeServiceTest extends PHPUnit_Framework_TestCase
         $employee->setEmpNumber($empNumber);
 
         //mock employee dao
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
             ->method('getEmployee')
             ->with($empNumber)
@@ -79,7 +79,7 @@ class HttpEmployeeServiceTest extends PHPUnit_Framework_TestCase
 
     public function testGetEmployeeDependants(){
 
-        $requestParams = $this->getMock('\Orangehrm\Rest\Http\RequestParams', ['getQueryParam']);
+        $requestParams = $this->getMockBuilder('\Orangehrm\Rest\Http\RequestParams')->setMethods(['getQueryParam'])->getMock();
         $requestParams->expects($this->once())
             ->method('getQueryParam')
             ->with('id')
@@ -94,7 +94,7 @@ class HttpEmployeeServiceTest extends PHPUnit_Framework_TestCase
         $employeeDependantsMockList [] = $employeeDependant;
 
         //mock employee dao
-        $mockDao = $this->getMock('EmployeeDao');
+        $mockDao = $this->getMockBuilder('EmployeeDao')->getMock();
         $mockDao->expects($this->once())
             ->method('getEmployeeDependents')
             ->with($empNumber)

--- a/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/CandidateServiceTest.php
+++ b/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/CandidateServiceTest.php
@@ -509,7 +509,9 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $expectedArray = array("" => "Select Action", 3 => "Reject", 4 => "Schedule Interview" );
         $allowedActions = array(3, 4);
         
-        $userObj = $this->getMock('User',array ('getAllowedActions'));
+        $userObj = $this->getMockBuilder('User')
+            ->setMethods(array ('getAllowedActions'))
+            ->getMock();
         $userObj->expects($this->once())
                 ->method('getAllowedActions')
                 ->with(PluginWorkflowStateMachine::FLOW_RECRUITMENT, 2)

--- a/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/CandidateServiceTest.php
+++ b/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/CandidateServiceTest.php
@@ -45,7 +45,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $allCandidatesList = TestDataService::loadObjectList('JobCandidate', $this->fixture, 'JobCandidate');
 	$allowedCandidateList = array(1,2,3);
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
 
         $candidateDao->expects($this->once())
                 ->method('getCandidateList')
@@ -71,7 +71,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
             }
         }
         
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
 
         $candidateDao->expects($this->once())
                 ->method('getCandidateNameList')
@@ -95,7 +95,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidatesVacancyList = TestDataService::loadObjectList('JobCandidateVacancy', $this->fixture, 'JobCandidateVacancy');
         $canVacList = array($candidatesVacancyList[2], $candidatesVacancyList[3], $candidatesVacancyList[4]);
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
 
         $candidateDao->expects($this->once())
                 ->method('searchCandidates')
@@ -116,13 +116,17 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $searchParam = new CandidateSearchParameters();
         $searchParam->setJobTitleCode('JOB002');
         
-        $candidateService = $this->getMock('CandidateService', array('buildSearchCountQuery'));        
+        $candidateService = $this->getMockBuilder('CandidateService')
+			->setMethods( array('buildSearchCountQuery'))
+			->getMock();        
         $candidateService->expects($this->once())
                 ->method('buildSearchCountQuery')
                 ->with($searchParam)
                 ->will($this->returnValue('searchCountQuery'));        
 
-        $candidateDao = $this->getMock('CandidateDao', array('getCandidateRecordsCount'));
+        $candidateDao = $this->getMockBuilder('CandidateDao')
+			->setMethods( array('getCandidateRecordsCount'))
+			->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateRecordsCount')
                 ->with('searchCountQuery')
@@ -142,7 +146,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidate = new JobCandidate();
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('saveCandidate')
                 ->with($candidate)
@@ -161,7 +165,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidateVacancy = new JobCandidateVacancy();
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('saveCandidateVacancy')
                 ->with($candidateVacancy)
@@ -180,7 +184,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $candidateVacancyList = TestDataService::loadObjectList('JobCandidateVacancy', $this->fixture, 'JobCandidateVacancy');
         $requiredObject = $candidateVacancyList[2];
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateVacancyById')
                 ->with(3)
@@ -197,7 +201,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetCandidateHistoryById() {
         $candidateHistoryList = TestDataService::loadObjectList('CandidateHistory', $this->fixture, 'CandidateHistory');
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateHistoryById')
                 ->with(1)
@@ -223,7 +227,9 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $toBeDeleteCandidateIds = array(1);
         $toBeDeletedRecords = array(1 =>array(1, 3));
         
-        $candidateDao = $this->getMock('CandidateDao', array('getAllVacancyIdsForCandidate', 'deleteCandidates', 'deleteCandidateVacancies'));
+        $candidateDao = $this->getMockBuilder('CandidateDao')
+			->setMethods( array('getAllVacancyIdsForCandidate', 'deleteCandidates', 'deleteCandidateVacancies'))
+			->getMock();
         
         $candidateDao->expects($this->any())
                      ->method('getAllVacancyIdsForCandidate')
@@ -250,7 +256,9 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $toBeDeleteCandidateIds = array(1);
         $toBeDeletedRecords = array(1 =>array(1, 3));
         
-        $candidateDao = $this->getMock('CandidateDao', array('getAllVacancyIdsForCandidate', 'deleteCandidates', 'deleteCandidateVacancies'));
+        $candidateDao = $this->getMockBuilder('CandidateDao')
+			->setMethods( array('getAllVacancyIdsForCandidate', 'deleteCandidates', 'deleteCandidateVacancies'))
+			->getMock();
         
         $candidateDao->expects($this->any())
                      ->method('getAllVacancyIdsForCandidate')
@@ -274,7 +282,9 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $toBeDeletedRecords = array(2 => array(1, 3));
         $toBeDeleteCandidateVacancies = array(array(2, 1), array(2, 3));
         
-        $candidateDao = $this->getMock('CandidateDao', array('getAllVacancyIdsForCandidate', 'deleteCandidates', 'deleteCandidateVacancies'));
+        $candidateDao = $this->getMockBuilder('CandidateDao')
+			->setMethods( array('getAllVacancyIdsForCandidate', 'deleteCandidates', 'deleteCandidateVacancies'))
+			->getMock();
         
         $candidateDao->expects($this->any())
                      ->method('getAllVacancyIdsForCandidate')
@@ -300,7 +310,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         
         $requiredObject = $candidatesList[1];
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateById')
                 ->with(2)
@@ -319,7 +329,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidate = new JobCandidate();
         
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('updateCandidate')
                 ->with($candidate)
@@ -338,7 +348,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidateHistory = new CandidateHistory();
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('saveCandidateHistory')
                 ->with($candidateHistory)
@@ -358,7 +368,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $candidatesHistory = TestDataService::loadObjectList('CandidateHistory', $this->fixture, 'CandidateHistory');
         $expectedresult = $candidatesHistory[0];
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateHistoryForCandidateId')
                 ->with(1,1)
@@ -372,7 +382,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testDeleteCandidates() {
 
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('deleteCandidates')
                 ->with(array(1,2))
@@ -391,7 +401,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetCandidateListForUserRole() {
         
         $exceptedValues = array(1,2);
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateListForUserRole')
                 ->with(HiringManagerUserRoleDecorator::HIRING_MANAGER, 1)
@@ -406,7 +416,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     public function testGetCanidateHistoryForUserRole() {
         
         $exceptedValues = array(1);
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCanidateHistoryForUserRole')
                 ->with(HiringManagerUserRoleDecorator::HIRING_MANAGER, 1, 1)
@@ -420,7 +430,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testIsHiringManager() {
         
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('isHiringManager')
                 ->with(1, 1)
@@ -434,7 +444,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     
     public function testIsInterviewer() {
         
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('isInterviewer')
                 ->with(1, 1)
@@ -450,7 +460,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidatesVacancy = TestDataService::loadObjectList('JobCandidateVacancy', $this->fixture, 'JobCandidateVacancy');
         $expectedresult = $candidatesVacancy[5];
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('getCandidateVacancyByCandidateIdAndVacancyId')
                 ->with(3,1)
@@ -472,13 +482,15 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
         $candidatesVacancy = TestDataService::loadObjectList('JobCandidateVacancy', $this->fixture, 'JobCandidateVacancy');
         $candidateVacancy = $candidatesVacancy[0];
         $userObj = new User();
-        $candidateService = $this->getMock('CandidateService', array ('getNextStateForCandidateVacancy'));
+        $candidateService = $this->getMockBuilder('CandidateService')
+			->setMethods( array ('getNextStateForCandidateVacancy'))
+			->getMock();
         $candidateService->expects($this->any())
                 ->method('getNextStateForCandidateVacancy')
                 ->with('SHORTLISTED', 3, $userObj)
                 ->will($this->returnValue('REJECTED'));
         
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('updateCandidateVacancy')
                 ->with($candidateVacancy)
@@ -508,7 +520,9 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
    
     public function testAddEmployee() {
         
-        $employeeServiceMock = $this->getMock('EmployeeService', array('saveEmployee'));
+        $employeeServiceMock = $this->getMockBuilder('EmployeeService')
+			->setMethods( array('saveEmployee'))
+			->getMock();
         $employeeServiceMock->expects($this->once())
                 ->method('saveEmployee')
                 ->will($this->returnValue(new Employee()));
@@ -524,7 +538,7 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidateHistory = new CandidateHistory();
         
-        $candidateDao = $this->getMock('CandidateDao');
+        $candidateDao = $this->getMockBuilder('CandidateDao')->getMock();
         $candidateDao->expects($this->once())
                 ->method('updateCandidateHistory')
                 ->with($candidateHistory)
@@ -538,7 +552,9 @@ class CandidateServiceTest extends PHPUnit_Framework_TestCase {
     
      public function testGetNextStateForCandidateVacancy() {
         
-        $userObj = $this->getMock('User',array ('getNextState'));
+        $userObj = $this->getMockBuilder('User')
+			->setMethods(array ('getNextState'))
+			->getMock();
         $userObj->expects($this->once())
                 ->method('getNextState')
                 ->with(PluginWorkflowStateMachine::FLOW_RECRUITMENT, 'SHORTLISTED', 3)

--- a/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/JobInterviewServiceTest.php
+++ b/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/JobInterviewServiceTest.php
@@ -52,7 +52,9 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 //        
 //        $parameters = array('candidateId' => 4, 'interviewDate' => '2011-08-18', 'fromTime' => '09:00:00', 'toTime' => '11:00:00');
 //
-//        $jobInterviewDao = $this->getMock('JobInterviewDao', array('getInterviewListByCandidateIdAndInterviewDateAndTime'));
+//        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')
+//			->setMethods( array('getInterviewListByCandidateIdAndInterviewDateAndTime'))
+//			->getMock();
 //
 //            $jobInterviewDao->expects($this->once())
 //                           ->method('getInterviewListByCandidateIdAndInterviewDateAndTime')
@@ -76,7 +78,9 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 //        
 //        $parameters = array('candidateId' => 4, 'interviewDate' => '2011-08-18', 'fromTime' => '09:00:00', 'toTime' => '11:00:00');
 //
-//        $jobInterviewDao = $this->getMock('JobInterviewDao', array('getInterviewListByCandidateIdAndInterviewDateAndTime'));
+//        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')
+//			->setMethods( array('getInterviewListByCandidateIdAndInterviewDateAndTime'))
+//			->getMock();
 //
 //            $jobInterviewDao->expects($this->once())
 //                           ->method('getInterviewListByCandidateIdAndInterviewDateAndTime')
@@ -96,7 +100,7 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
         $interviews = TestDataService::loadObjectList('JobInterview', $this->fixture, 'JobInterview');
         $expectedresult = $interviews[0];
 
-        $jobInterviewDao = $this->getMock('JobInterviewDao');
+        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')->getMock();
         $jobInterviewDao->expects($this->once())
                 ->method('getInterviewById')
                 ->with(1)
@@ -112,7 +116,7 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 
         $interviewInterViewer = TestDataService::loadObjectList('JobInterviewInterviewer', $this->fixture, 'JobInterviewInterviewer');
         $expectedresult = $interviewInterViewer;
-        $jobInterviewDao = $this->getMock('JobInterviewDao');
+        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')->getMock();
         $jobInterviewDao->expects($this->once())
                 ->method('getInterviewersByInterviewId')
                 ->with(1)
@@ -128,7 +132,7 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 
         $interviews = TestDataService::loadObjectList('JobInterview', $this->fixture, 'JobInterview');
         $expectedresult = $interviews[1];
-        $jobInterviewDao = $this->getMock('JobInterviewDao');
+        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')->getMock();
         $jobInterviewDao->expects($this->once())
                 ->method('getInterviewsByCandidateVacancyId')
                 ->with(10)
@@ -144,7 +148,7 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 
         $jobInterview = new JobInterview();
 
-        $jobInterviewDao = $this->getMock('JobInterviewDao');
+        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')->getMock();
         $jobInterviewDao->expects($this->once())
                 ->method('saveJobInterview')
                 ->with($jobInterview)
@@ -160,7 +164,7 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 
         $jobInterview = new JobInterview();
         
-        $jobInterviewDao = $this->getMock('JobInterviewDao');
+        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')->getMock();
         $jobInterviewDao->expects($this->once())
                 ->method('updateJobInterview')
                 ->with($jobInterview)
@@ -176,7 +180,7 @@ class JobInterviewServiceTest extends PHPUnit_Framework_TestCase {
 
         $candidateHistory = TestDataService::loadObjectList('CandidateHistory', $this->fixture, 'CandidateHistory');
         $expectedresult = $candidateHistory[2];
-        $jobInterviewDao = $this->getMock('JobInterviewDao');
+        $jobInterviewDao = $this->getMockBuilder('JobInterviewDao')->getMock();
         $jobInterviewDao->expects($this->once())
                 ->method('getInterviewScheduledHistoryByInterviewId')
                 ->with(1)

--- a/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/RecruitmentAttachmentServiceTest.php
+++ b/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/RecruitmentAttachmentServiceTest.php
@@ -45,7 +45,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 
 		$resume = new JobVacancyAttachment();
 
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('saveVacancyAttachment')
 			->with($resume)
@@ -64,7 +64,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 
 		$resume = new JobCandidateAttachment();
 
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('saveCandidateAttachment')
 			->with($resume)
@@ -85,7 +85,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$vacancyList = TestDataService::loadObjectList('JobVacancyAttachment', $this->fixture, 'JobVacancyAttachment');
 		$testVacancyList = array($vacancyList[0], $vacancyList[1]);
 
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getVacancyAttachment')
@@ -107,7 +107,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$candidateList = TestDataService::loadObjectList('JobCandidateAttachment', $this->fixture, 'JobCandidateAttachment');
 		$testCandidateList = array($candidateList[0], $candidateList[1]);
 
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getCandidateAttachment')
@@ -131,7 +131,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$id = 1;
 		$screen = "CANDIDATE";
 		$candidateList = TestDataService::loadObjectList('JobCandidateAttachment', $this->fixture, 'JobCandidateAttachment');
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getCandidateAttachment')
@@ -148,7 +148,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$id = 1;
 		$screen = "VACANCY";
 		$candidateList = TestDataService::loadObjectList('JobVacancyAttachment', $this->fixture, 'JobVacancyAttachment');
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getVacancyAttachment')
@@ -164,7 +164,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$id = 1;
 		$screen = "INTERVIEW";
 		$candidateList = TestDataService::loadObjectList('JobInterviewAttachment', $this->fixture, 'JobInterviewAttachment');
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getInterviewAttachment')
@@ -188,7 +188,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$id = 1;
 		$screen = "VACANCY";
 		$candidateList = TestDataService::loadObjectList('JobVacancyAttachment', $this->fixture, 'JobVacancyAttachment');
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getVacancyAttachments')
@@ -204,7 +204,7 @@ class RecruitmentAttachmentServiceTest extends PHPUnit_Framework_TestCase {
 		$id = 1;
 		$screen = "INTERVIEW";
 		$candidateList = TestDataService::loadObjectList('JobInterviewAttachment', $this->fixture, 'JobInterviewAttachment');
-		$recruitmentAttachmentDao = $this->getMock('RecruitmentAttachmentDao');
+		$recruitmentAttachmentDao = $this->getMockBuilder('RecruitmentAttachmentDao')->getMock();
 
 		$recruitmentAttachmentDao->expects($this->once())
 			->method('getInterviewAttachments')

--- a/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/VacancyServiceTest.php
+++ b/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/VacancyServiceTest.php
@@ -239,7 +239,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 
         foreach ($vacancyIdsSet as $vacancyIds) {
         
-            $vacancyDao = $this->getMock('VacancyDao', array('deleteVacancies'));
+            $vacancyDao = $this->getMockBuilder('VacancyDao')->setMethods(array('deleteVacancies'))->getMock();
 
             $vacancyDao->expects($this->once())
                        ->method('deleteVacancies')
@@ -265,7 +265,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 
         foreach ($vacancyIdsSet as $vacancyIds) {
         
-            $vacancyDao = $this->getMock('VacancyDao', array('deleteVacancies'));
+            $vacancyDao = $this->getMockBuilder('VacancyDao')->setMethods(array('deleteVacancies'))->getMock();
 
             $vacancyDao->expects($this->once())
                        ->method('deleteVacancies')
@@ -300,7 +300,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 
 		$srchParams = array('jobTitle' => 'JOB002', 'jobVacancy' => '2', 'hiringManager' => '2', 'status' => '1');
 		
-		$vacancyDao = $this->getMock('VacancyDao', array('searchVacanciesCount'));
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->setMethods(array('searchVacanciesCount'))->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('searchVacanciesCount')
@@ -323,7 +323,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
         $allVacancyList = TestDataService::loadObjectList('JobVacancy', $this->fixture, 'JobVacancy');
 		$returnedVacancy = $allVacancyList[0];
 		
-		$vacancyDao = $this->getMock('VacancyDao', array('getVacancyById'));
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->setMethods(array('getVacancyById'))->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getVacancyById')
@@ -348,7 +348,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
         $parameters = array('HIRING MANAGER', $allEmployeeList[0]);
 		$returnedVacancy[0] = $allVacancyList[0];
 		
-		$vacancyDao = $this->getMock('VacancyDao', array('getVacancyListForUserRole'));
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->setMethods(array('getVacancyListForUserRole'))->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getVacancyListForUserRole')
@@ -373,7 +373,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
         $parameters = array('HIRING MANAGER', $allEmployeeList[0]);
 		$returnedVacancy[0] = $allVacancyList[0];
 		
-		$vacancyDao = $this->getMock('VacancyDao', array('getVacancyListForUserRole'));
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->setMethods(array('getVacancyListForUserRole'))->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getVacancyListForUserRole')

--- a/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/VacancyServiceTest.php
+++ b/symfony/plugins/orangehrmRecruitmentPlugin/test/model/service/VacancyServiceTest.php
@@ -45,7 +45,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 
 		$hiringMangersList = array(1 => array('id' => 1, 'name' => "Kayla Abbey"), 2 => array('id' => 2, 'name' => "Ashley Abel"));
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 		$allowedVacancyList = array(1,2);
 		$vacancyDao->expects($this->once())
 			->method('getHiringManagersList')
@@ -67,7 +67,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 		$allVacancyList = TestDataService::loadObjectList('JobVacancy', $this->fixture, 'JobVacancy');
 		$vacancyList = array($allVacancyList[1], $allVacancyList[2]);
 		$allowedVacancyList = array(1,2);
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 		$vacancyDao->expects($this->once())
 			->method('getVacancyListForJobTitle')
 			->with($jobTitle)
@@ -87,7 +87,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 		$jobTitle = "JOB002";
 		$readList = array(array('id' => 2, 'name' => 'A 2011'), array('id' => 3, 'name' => 'B 2011'));
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getVacancyListForJobTitle')
@@ -107,7 +107,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 
 		$allVacancyList = TestDataService::loadObjectList('JobVacancy', $this->fixture, 'JobVacancy');
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getVacancyList')
@@ -127,7 +127,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 		$allVacancyList = TestDataService::loadObjectList('JobVacancy', $this->fixture, 'JobVacancy');
 		$activeVacancyList = array($allVacancyList[0], $allVacancyList[2]);
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getAllVacancies')
@@ -152,7 +152,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
             $vacancyNameArray[] = array('id' => $vacancy->getId(), 'name' => $vacancy->getName());
         }
         
-        $vacancyDao = $this->getMock('VacancyDao');
+        $vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
         
         $vacancyDao->expects($this->once())
             ->method('getVacancyPropertyList')
@@ -173,7 +173,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 		$allVacancyList = TestDataService::loadObjectList('JobVacancy', $this->fixture, 'JobVacancy');
 		$publishedActiveList = array($allVacancyList[0], $allVacancyList[2]);
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('getPublishedVacancies')
@@ -199,7 +199,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 		$jobVacancy->status = 1;
 		$jobVacancy->definedTime = date('Y-m-d H:i:s');
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 		$vacancyDao->expects($this->once())
 			->method('saveJobVacancy')
 			->with($jobVacancy)
@@ -217,7 +217,7 @@ class VacancyServiceTest extends PHPUnit_Framework_TestCase {
 		$vacancyList = TestDataService::fetchObject('JobVacancy', 2);
 
 
-		$vacancyDao = $this->getMock('VacancyDao');
+		$vacancyDao = $this->getMockBuilder('VacancyDao')->getMock();
 
 		$vacancyDao->expects($this->once())
 			->method('searchVacancies')

--- a/symfony/plugins/orangehrmTimePlugin/test/model/dao/TimesheetDaoTest.php
+++ b/symfony/plugins/orangehrmTimePlugin/test/model/dao/TimesheetDaoTest.php
@@ -511,7 +511,9 @@ class TimesheetDaoTest extends PHPUnit_Framework_TestCase {
 
     public function testGetTimesheetTimeFormat() {
 
-        $configDao = $this->getMock('ConfigDao', array('getValue'));
+        $configDao = $this->getMockBuilder('ConfigDao')
+			->setMethods( array('getValue'))
+			->getMock();
         $configDao->expects($this->once())
                      ->method('getValue')
                      ->with(ConfigService::KEY_TIMESHEET_TIME_FORMAT)

--- a/symfony/plugins/orangehrmTimePlugin/test/model/service/TimesheetPeriodServiceTest.php
+++ b/symfony/plugins/orangehrmTimePlugin/test/model/service/TimesheetPeriodServiceTest.php
@@ -67,7 +67,9 @@ class TimesheetPeriodServiceTest extends PHPUnit_Framework_Testcase {
                 $xmlString = TestDataService::getRecords("SELECT value from hs_hr_config WHERE `key` = '" . $key . "'");
                 $value = $xmlString[0]['value']; 
         
-		$timesheetPeriodDaoMock = $this->getMock('TimesheetPeriodDao', array('getDefinedTimesheetPeriod'));
+		$timesheetPeriodDaoMock = $this->getMockBuilder('TimesheetPeriodDao')
+			->setMethods( array('getDefinedTimesheetPeriod'))
+			->getMock();
 		$timesheetPeriodDaoMock->expects($this->once())
 			->method('getDefinedTimesheetPeriod')
 			->will($this->returnValue($value));
@@ -88,7 +90,9 @@ class TimesheetPeriodServiceTest extends PHPUnit_Framework_Testcase {
                 $xmlString = TestDataService::getRecords("SELECT value from hs_hr_config WHERE `key` = '" . $key . "'");
                 $boolean = $xmlString[0]['value'];
                 
-		$timesheetPeriodDaoMock = $this->getMock('TimesheetPeriodDao', array('isTimesheetPeriodDefined'));
+		$timesheetPeriodDaoMock = $this->getMockBuilder('TimesheetPeriodDao')
+			->setMethods( array('isTimesheetPeriodDefined'))
+			->getMock();
 		$timesheetPeriodDaoMock->expects($this->once())
 			->method('isTimesheetPeriodDefined')
 			->will($this->returnValue($boolean));
@@ -103,7 +107,9 @@ class TimesheetPeriodServiceTest extends PHPUnit_Framework_Testcase {
 
 		$startDay='1';
 		$xml = '<TimesheetPeriod><PeriodType>Weekly</PeriodType><ClassName>WeeklyTimesheetPeriod</ClassName><StartDate>1</StartDate><Heading>Week</Heading></TimesheetPeriod>';
-		$timesheetPeriodDaoMock = $this->getMock('TimesheetPeriodDao', array('setTimesheetPeriod','setTimesheetPeriodAndStartDate'));
+		$timesheetPeriodDaoMock = $this->getMockBuilder('TimesheetPeriodDao')
+			->setMethods( array('setTimesheetPeriod','setTimesheetPeriodAndStartDate'))
+			->getMock();
 		$timesheetPeriodDaoMock->expects($this->once())
 			->method('setTimesheetPeriod')
 			->will($this->returnValue(true));
@@ -131,7 +137,9 @@ class TimesheetPeriodServiceTest extends PHPUnit_Framework_Testcase {
                 $xmlString = TestDataService::getRecords("SELECT value from hs_hr_config WHERE `key` = '" . $key . "'");
                 $value = $xmlString[0]['value'];                 
                 
-		$timesheetPeriodDaoMock = $this->getMock('TimesheetPeriodDao', array('getDefinedTimesheetPeriod'));
+		$timesheetPeriodDaoMock = $this->getMockBuilder('TimesheetPeriodDao')
+			->setMethods( array('getDefinedTimesheetPeriod'))
+			->getMock();
 		$timesheetPeriodDaoMock->expects($this->once())
 			->method('getDefinedTimesheetPeriod')
 			->will($this->returnValue($value));

--- a/symfony/plugins/orangehrmTimePlugin/test/model/service/TimesheetServiceTest.php
+++ b/symfony/plugins/orangehrmTimePlugin/test/model/service/TimesheetServiceTest.php
@@ -78,7 +78,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
 
         $timesheet = $timesheets[0];
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('saveTimesheet'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('saveTimesheet'))
+			->getMock();
 
         $timesheetDaoMock->expects($this->once())
                 ->method('saveTimesheet')
@@ -96,7 +98,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheetActionLogRecords = TestDataService::loadObjectList('TimesheetActionLog', $this->fixture, 'TimesheetActionLog');
         $timesheetActionLog = $timesheetActionLogRecords[0];
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('saveTimesheetActionLog'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('saveTimesheetActionLog'))
+			->getMock();
 
         $timesheetDaoMock->expects($this->once())
                 ->method('saveTimesheetActionLog')
@@ -114,7 +118,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheetId = 1;
         $timesheet = TestDataService::fetchObject('Timesheet', $timesheetId);
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetById'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetById'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetById')
                 ->with($timesheetId)
@@ -133,7 +139,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheetItemId = 2;
         $timesheetItem = TestDataService::fetchObject('TimesheetItem', $timesheetItemId);
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetItemById'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetItemById'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetItemById')
                 ->with($timesheetItemId)
@@ -154,7 +162,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheets = TestDataService::loadObjectList('Timesheet', $this->fixture, 'Timesheet');
         $temp = $timesheets[0];
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetByStartDate'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetByStartDate'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetByStartDate')
                 ->with($startDate)
@@ -177,7 +187,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $startDate = "2011-04-18";
         $timesheet = TestDataService::fetchObject('Timesheet', $timesheetId);
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetByStartDateAndEmployeeId'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetByStartDateAndEmployeeId'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetByStartDateAndEmployeeId')
                 ->with($startDate, $employeeId)
@@ -198,7 +210,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheetId = 2;
         $timesheet = TestDataService::fetchObject('Timesheet', $timesheetId);
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetByEmployeeId'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetByEmployeeId'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetByEmployeeId')
                 ->with($employeeId)
@@ -227,7 +241,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
 
         $timesheetArray = array($timesheet1, $timesheet2);
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetByEmployeeIdAndState'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetByEmployeeIdAndState'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetByEmployeeIdAndState')
                 ->with($employeeId, $stateList)
@@ -254,7 +270,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
     public function testGetPendingApprovelTimesheetsForAdmin() {
         $timesheetId = 6;
         $timesheet = TestDataService::fetchObject('Timesheet', $timesheetId);
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getPendingApprovelTimesheetsForAdmin'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getPendingApprovelTimesheetsForAdmin'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getPendingApprovelTimesheetsForAdmin')
                 ->will($this->returnValue($timesheet));
@@ -268,7 +286,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
 
     public function testConvertDurationToHours() {
         
-        $timesheetService = $this->getMock('TimesheetService', array('getTimesheetTimeFormat'));
+        $timesheetService = $this->getMockBuilder('TimesheetService')
+			->setMethods( array('getTimesheetTimeFormat'))
+			->getMock();
         $timesheetService->expects($this->exactly(2))
                          ->method('getTimesheetTimeFormat')
                          ->will($this->returnValue(1));
@@ -294,7 +314,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheetActionLogRecord = TestDataService::fetchObject('TimesheetActionLog', $timesheetActionLogId);
 //                $timesheetActionLog = $timesheetActionLogRecords[0];
 
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetActionLogByTimesheetId'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetActionLogByTimesheetId'))
+			->getMock();
 
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetActionLogByTimesheetId')
@@ -313,7 +335,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $activityId = 1;
         $activity = TestDataService::fetchObject('ProjectActivity', $activityId);
 
-        $activityDaoMock = $this->getMock('TimesheetDao', array('getActivityByActivityId'));
+        $activityDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getActivityByActivityId'))
+			->getMock();
         $activityDaoMock->expects($this->once())
                 ->method('getActivityByActivityId')
                 ->with($activityId)
@@ -347,7 +371,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $latestEndDate = "2011-04-28";
         $employeeId = 1;
 
-        $timehseetDaoMock = $this->getMock('TimesheetDao', array('getLatestTimesheetEndDate'));
+        $timehseetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getLatestTimesheetEndDate'))
+			->getMock();
         $timehseetDaoMock->expects($this->once())
                 ->method('getLatestTimesheetEndDate')
                 ->with($employeeId)
@@ -366,7 +392,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $endDate = "2011-04-20";
         $isValid = 0;
 
-        $timehseetDaoMock = $this->getMock('TimesheetDao', array('checkForOverlappingTimesheets'));
+        $timehseetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('checkForOverlappingTimesheets'))
+			->getMock();
         $timehseetDaoMock->expects($this->once())
                 ->method('checkForOverlappingTimesheets')
                 ->with($startDate, $endDate, $employeeId)
@@ -385,7 +413,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheetId = 9;
         $timesheet = TestDataService::fetchObject('Timesheet', $timesheetId);
 
-        $timehseetDaoMock = $this->getMock('TimesheetDao', array('checkForMatchingTimesheetForCurrentDate'));
+        $timehseetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('checkForMatchingTimesheetForCurrentDate'))
+			->getMock();
         $timehseetDaoMock->expects($this->once())
                 ->method('checkForMatchingTimesheetForCurrentDate')
                 ->with($employeeId, $currentDate)
@@ -428,7 +458,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $timesheets[] = $timesheet2;
         $timesheets[] = $timesheet3;
         
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetListByEmployeeIdAndState'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetListByEmployeeIdAndState'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetListByEmployeeIdAndState')
                 ->with($empIdList, $stateList, 100)
@@ -441,7 +473,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         $this->assertEquals($timesheets[0], $result[0]);
         $this->assertEquals($timesheets[1], $result[1]);
         
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getTimesheetListByEmployeeIdAndState'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getTimesheetListByEmployeeIdAndState'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getTimesheetListByEmployeeIdAndState')
                 ->with(null, null, null)
@@ -464,7 +498,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         
         $projects = array($project1, $project2);
         
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getProjectNameList'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getProjectNameList'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getProjectNameList')
                 ->with(true, 'project_id', 'ASC')
@@ -487,7 +523,9 @@ class TimesheetServiceTest extends PHPUnit_Framework_Testcase {
         
         $activities = array($project1);
         
-        $timesheetDaoMock = $this->getMock('TimesheetDao', array('getProjectActivityListByPorjectId'));
+        $timesheetDaoMock = $this->getMockBuilder('TimesheetDao')
+			->setMethods( array('getProjectActivityListByPorjectId'))
+			->getMock();
         $timesheetDaoMock->expects($this->once())
                 ->method('getProjectActivityListByPorjectId')
                 ->with(1, true)

--- a/symfony/test/model/auth/service/AuthenticationServiceTest.php
+++ b/symfony/test/model/auth/service/AuthenticationServiceTest.php
@@ -73,13 +73,13 @@ class AuthenticationServiceTest extends PHPUnit_Framework_TestCase {
         $user = new Users();
         $user->setUserName('test_user');
 
-        $mockService = $this->getMock('SystemUserService', array('getCredentials'));
+        $mockService = $this->getMockBuilder('SystemUserService')->setMethods(array('getCredentials'))->getMock();
         $mockService->expects($this->once())
                 ->method('getCredentials')
                 ->with('test_user', 'test_password')
                 ->will($this->returnValue($user));
 
-        $mockCookieManager = $this->getMock('CookieManager', array('setCookie'));
+        $mockCookieManager = $this->getMockBuilder('CookieManager')->setMethods(array('setCookie'))->getMock();
         $mockCookieManager->expects($this->once())
                 ->method('setCookie')
                 ->with('Loggedin', 'True', 0, '/');

--- a/symfony/test/model/core/service/EmailServiceTest.php
+++ b/symfony/test/model/core/service/EmailServiceTest.php
@@ -33,12 +33,12 @@ class EmailServiceTest extends PHPUnit_Framework_TestCase{
                 'body' => 'orangehrmLeavePlugin/modules/leave/templates/mail/en_US/leaveApplicationBody.txt', 
                 'subject' => 'orangehrmLeavePlugin/modules/leave/templates/mail/en_US/leaveApplicationSubject.txt'));
         
-        $configService = $this->getMock('ConfigService', array('getAdminLocalizationDefaultLanguage'));
+        $configService = $this->getMockBuilder('ConfigService')->setMethods(array('getAdminLocalizationDefaultLanguage'))->getMock();
         $configService->expects($this->once())
                 ->method('getAdminLocalizationDefaultLanguage')
                 ->will($this->returnValue($locale)); 
         
-        $emailDao = $this->getMock('EmailDao', array('getEmailTemplateMatches'));
+        $emailDao = $this->getMockBuilder('EmailDao')->setMethods(array('getEmailTemplateMatches'))->getMock();
         $emailDao->expects($this->at(0))
                 ->method('getEmailTemplateMatches')
                 ->with($email, $locale, $recipientRole, $performerRole)
@@ -72,12 +72,12 @@ class EmailServiceTest extends PHPUnit_Framework_TestCase{
                 'body' => 'orangehrmLeavePlugin/modules/leave/templates/mail/en_US/leaveApplicationBody.txt', 
                 'subject' => 'orangehrmLeavePlugin/modules/leave/templates/mail/en_US/leaveApplicationSubject.txt'));    
         
-        $configService = $this->getMock('ConfigService', array('getAdminLocalizationDefaultLanguage'));
+        $configService = $this->getMockBuilder('ConfigService')->setMethods(array('getAdminLocalizationDefaultLanguage'))->getMock();
         $configService->expects($this->once())
                 ->method('getAdminLocalizationDefaultLanguage')
                 ->will($this->returnValue($locale)); 
         
-        $emailDao = $this->getMock('EmailDao', array('getEmailTemplateMatches'));
+        $emailDao = $this->getMockBuilder('EmailDao')->setMethods(array('getEmailTemplateMatches'))->getMock();
         $emailDao->expects($this->once())
                 ->method('getEmailTemplateMatches')
                 ->with($email, $locale, $recipientRole, $performerRole)


### PR DESCRIPTION
Replaced getMock() in unit tests with getMockBuilder().  