### PR TITLE
The upgrader fails at the system check stage, because the SystemCheckSuccess

### DIFF
--- a/upgrader/apps/upgrader/modules/upgrade/templates/executeSystemCheckSuccess.php
+++ b/upgrader/apps/upgrader/modules/upgrade/templates/executeSystemCheckSuccess.php
@@ -78,7 +78,7 @@ function sysCheckPassed() {
             <td align="right" class="tdValues"><strong>
             <?php
                $dbInfo = $sf_user->getAttribute('dbInfo');
-               if(function_exists('mysqli_connect') && ($conn = @mysqli_connect($dbInfo['host'], $dbInfo['username'], $dbInfo['password'], "", $dbInfo['port']))) {
+               if(function_exists('mysqli_connect') && ($conn = @mysqli_connect($dbInfo['host'], $dbInfo['username'], $dbInfo['password'], $dbInfo['database'], $dbInfo['port']))) {
 
 	              $mysqlServer = mysqli_get_server_info($conn);
 


### PR DESCRIPTION
template checks database connectivity without specifying the database to use.