### PR TITLE
OHRM-77

### DIFF
--- a/installer/environmentCheck/system_requirements.yml
+++ b/installer/environmentCheck/system_requirements.yml
@@ -5,7 +5,7 @@ phpversion:
 
 mysqlversion:
     min: '5.5'
-    max: '5.7.22'
+    max: '5.7.23'
     excludeRange: []
 
 mariadbversion:


### PR DESCRIPTION
cannot install in MySQL 5.7.23, suporting versionis equal or lesser version than 5.7.22