### PR TITLE
Fix for issue outlined in #178

### DIFF
--- a/symfony/plugins/orangehrmPimPlugin/lib/service/EmployeeEventService.php
+++ b/symfony/plugins/orangehrmPimPlugin/lib/service/EmployeeEventService.php
@@ -80,7 +80,7 @@ class EmployeeEventService extends BaseService {
         $employeeEvent->setEvent($event);
         $employeeEvent->setNote($note);
         $employeeEvent->setCreatedBy($createdBy);
-        $employeeEvent->setCreatedDate(date("Y-m-d h:i:sa"));
+        $employeeEvent->setCreatedDate(date("Y-m-d H:i:s"));
         $this->saveEmployeeEvent($employeeEvent);
     }
 


### PR DESCRIPTION
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2019-02-07 01:11:09pm' for column 'created_date' at row 1 in /var/www/hrm-devel/symfony/plugins/orangehrmPimPlugin/lib/dao/EmployeeEventDao.php:36

Changed date format from 12-hour with AM/PM notation to 24-hour format.  The former breaks on some versions of MySQL/MariaDB.