### PR TITLE
OHRM-529: fixing csrf token issue when upgrading from version below 3.1.2

### DIFF
--- a/upgrader/apps/upgrader/lib/schemaIncrementTasks/SchemaIncrementTask59.php
+++ b/upgrader/apps/upgrader/lib/schemaIncrementTasks/SchemaIncrementTask59.php
@@ -69,7 +69,7 @@ class SchemaIncrementTask59 extends SchemaIncrementTask {
     }
 
     public function createCsrfKey() {
-        return \phpseclib\Crypt\Random::string(55);
+        return bin2hex(\phpseclib\Crypt\Random::string(55));
     }
 
 }

--- a/upgrader/apps/upgrader/lib/schemaIncrementTasks/SchemaIncrementTask60.php
+++ b/upgrader/apps/upgrader/lib/schemaIncrementTasks/SchemaIncrementTask60.php
@@ -101,7 +101,7 @@ class SchemaIncrementTask60 extends SchemaIncrementTask {
     }
 
     public function createCsrfKey() {
-        return \phpseclib\Crypt\Random::string(55);
+        return bin2hex(\phpseclib\Crypt\Random::string(55));
     }
 
 }


### PR DESCRIPTION
using the same code used in application installer.