### PR TITLE
[dev-tools]:Fix error when creating test db

### DIFF
--- a/devTools/general/create-test-db.php
+++ b/devTools/general/create-test-db.php
@@ -58,7 +58,7 @@ if ($returnStatus !== 0) {
 }
 
 
-$cmd = "mysql -h {$dbHost} --port={$dbPort} -u root -p{$mysqlRootPwd} {$testDb} < {$tempFile}";
+$cmd = "mysql -h {$dbHost} --port={$dbPort} -u root -p{$mysqlRootPwd} < {$tempFile}";
 
 exec($cmd, $output, $returnStatus);
 


### PR DESCRIPTION
Failed to create a test database if the database does not exist in DB.