### PR TITLE
OHRM5X-458:[PIM - Report to] Assign Supervisor/Subordinate field type should be similar to employee autocomplete field

### DIFF
--- a/symfony/client/src/orangehrmPimPlugin/components/EditEmployeeReportTo.vue
+++ b/symfony/client/src/orangehrmPimPlugin/components/EditEmployeeReportTo.vue
@@ -26,7 +26,7 @@
       <oxd-form-row>
         <oxd-grid :cols="3" class="orangehrm-full-width-grid">
           <oxd-grid-item>
-            <report-to-employee-dropdown
+            <report-to-employee-autocomplete
               v-model="reportTo.employee"
               required
               disabled
@@ -66,10 +66,10 @@
 
 <script>
 import {required} from '@orangehrm/core/util/validation/rules';
-import ReportToEmployeeDropdown from '@/orangehrmPimPlugin/components/ReportToEmployeeDropdown';
+import ReportToEmployeeAutocomplete from '@/orangehrmPimPlugin/components/ReportToEmployeeAutocomplete';
 
 const reportToModel = {
-  employee: [],
+  employee: null,
   reportingMethodId: [],
 };
 export default {
@@ -105,7 +105,7 @@ export default {
   },
 
   components: {
-    'report-to-employee-dropdown': ReportToEmployeeDropdown,
+    'report-to-employee-autocomplete': ReportToEmployeeAutocomplete,
   },
 
   data() {
@@ -161,18 +161,20 @@ export default {
       })
       .then(response => {
         const {data} = response.data;
-        this.reportTo.employee = [
-          {
-            id:
-              this.type === 'Supervisor'
-                ? data.supervisor.empNumber
-                : data.subordinate.empNumber,
-            label:
-              this.type === 'Supervisor'
-                ? `${data.supervisor.firstName} ${data.supervisor.lastName}`
-                : `${data.subordinate.firstName} ${data.subordinate.lastName}`,
-          },
-        ];
+        this.reportTo.employee = {
+          id:
+            this.type === 'Supervisor'
+              ? data.supervisor.empNumber
+              : data.subordinate.empNumber,
+          label:
+            this.type === 'Supervisor'
+              ? `${data.supervisor.firstName} ${data.supervisor.middleName} ${data.supervisor.lastName}`
+              : `${data.subordinate.firstName} ${data.subordinate.middleName} ${data.subordinate.lastName}`,
+          isPastEmployee:
+            this.type === 'Supervisor'
+              ? data.supervisor.terminationId
+              : data.subordinate.terminationId,
+        };
         this.reportTo.reportingMethodId = this.reportingMethods.filter(
           item => item.id === data.reportingMethod.id,
         );

--- a/symfony/client/src/orangehrmPimPlugin/components/ReportToEmployeeAutocomplete.vue
+++ b/symfony/client/src/orangehrmPimPlugin/components/ReportToEmployeeAutocomplete.vue
@@ -20,22 +20,35 @@
 
 <template>
   <oxd-input-field
-    type="dropdown"
+    type="autocomplete"
     label="Name"
+    :clear="false"
     :create-options="loadEmployees"
-    :lazyLoad="true"
-  />
+  >
+    <template v-slot:afterSelected="{data}">
+      <template v-if="data.isPastEmployee">(Past Employee)</template>
+    </template>
+    <template v-slot:option="{data, text}">
+      <span v-html="text"></span>
+      <div v-if="data.isPastEmployee" class="past-employee-tag">
+        (Past Employee)
+      </div>
+    </template>
+  </oxd-input-field>
 </template>
 
 <script>
 import {APIService} from '@orangehrm/core/util/services/api.service';
 export default {
-  name: 'report-to-employee-dropdown',
+  name: 'report-to-employee-autocomplete',
 
   props: {
     api: {
       type: String,
       required: true,
+    },
+    params: {
+      type: Object,
     },
   },
 
@@ -52,13 +65,15 @@ export default {
           this.http
             .getAll({
               nameOrId: serachParam,
+              ...this.params,
             })
             .then(({data}) => {
               resolve(
                 data.data.map(employee => {
                   return {
                     id: employee.empNumber,
-                    label: `${employee.firstName} ${employee.lastName}`,
+                    label: `${employee.firstName} ${employee.middleName} ${employee.lastName}`,
+                    isPastEmployee: employee.terminationId ? true : false,
                   };
                 }),
               );

--- a/symfony/client/src/orangehrmPimPlugin/components/SaveEmployeeReportTo.vue
+++ b/symfony/client/src/orangehrmPimPlugin/components/SaveEmployeeReportTo.vue
@@ -26,7 +26,7 @@
       <oxd-form-row>
         <oxd-grid :cols="3" class="orangehrm-full-width-grid">
           <oxd-grid-item>
-            <report-to-employee-dropdown
+            <report-to-employee-autocomplete
               v-model="reportTo.employee"
               :rules="rules.employee"
               :api="api"
@@ -63,11 +63,11 @@
 </template>
 
 <script>
-import ReportToEmployeeDropdown from '@/orangehrmPimPlugin/components/ReportToEmployeeDropdown';
+import ReportToEmployeeAutocomplete from '@/orangehrmPimPlugin/components/ReportToEmployeeAutocomplete';
 import {required} from '@orangehrm/core/util/validation/rules';
 
 const reportToModel = {
-  employee: [],
+  employee: null,
   reportingMethodId: [],
 };
 
@@ -96,7 +96,7 @@ export default {
   },
 
   components: {
-    'report-to-employee-dropdown': ReportToEmployeeDropdown,
+    'report-to-employee-autocomplete': ReportToEmployeeAutocomplete,
   },
 
   data() {
@@ -122,7 +122,7 @@ export default {
       this.isLoading = true;
       this.http
         .create({
-          empNumber: this.reportTo.employee.map(item => item.id)[0],
+          empNumber: this.reportTo.employee?.id,
           reportingMethodId: this.reportTo.reportingMethodId.map(
             item => item.id,
           )[0],

--- a/symfony/plugins/orangehrmPimPlugin/Api/Model/EmployeeSubordinateModel.php
+++ b/symfony/plugins/orangehrmPimPlugin/Api/Model/EmployeeSubordinateModel.php
@@ -36,6 +36,7 @@ class EmployeeSubordinateModel implements Normalizable
                 ['getSubordinate', 'getFirstName'],
                 ['getSubordinate', 'getLastName'],
                 ['getSubordinate', 'getMiddleName'],
+                ['getSubordinate', 'getEmployeeTerminationRecord', 'getId'],
                 ['getReportingMethod', 'getId'],
                 ['getReportingMethod', 'getName'],
             ]
@@ -46,6 +47,7 @@ class EmployeeSubordinateModel implements Normalizable
                 ['subordinate', 'firstName'],
                 ['subordinate', 'lastName'],
                 ['subordinate', 'middleName'],
+                ['subordinate', 'terminationId'],
                 ['reportingMethod', 'id'],
                 ['reportingMethod', 'name'],
             ]

--- a/symfony/plugins/orangehrmPimPlugin/Api/Model/EmployeeSupervisorModel.php
+++ b/symfony/plugins/orangehrmPimPlugin/Api/Model/EmployeeSupervisorModel.php
@@ -36,6 +36,7 @@ class EmployeeSupervisorModel implements Normalizable
                 ['getSupervisor', 'getFirstName'],
                 ['getSupervisor', 'getLastName'],
                 ['getSupervisor', 'getMiddleName'],
+                ['getSupervisor', 'getEmployeeTerminationRecord', 'getId'],
                 ['getReportingMethod', 'getId'],
                 ['getReportingMethod', 'getName'],
             ]
@@ -46,6 +47,7 @@ class EmployeeSupervisorModel implements Normalizable
                 ['supervisor', 'firstName'],
                 ['supervisor', 'lastName'],
                 ['supervisor', 'middleName'],
+                ['supervisor', 'terminationId'],
                 ['reportingMethod', 'id'],
                 ['reportingMethod', 'name'],
             ]

--- a/symfony/plugins/orangehrmPimPlugin/test/Api/EmployeeSubordinateAPITest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/Api/EmployeeSubordinateAPITest.php
@@ -117,7 +117,7 @@ class EmployeeSubordinateAPITest extends EndpointTestCase
         $result = $api->getOne();
         $this->assertEquals(
             [
-                'subordinate' => ['empNumber' => 2, 'firstName' => 'Peter', 'lastName' => 'Samuel', 'middleName' => ''],
+                'subordinate' => ['empNumber' => 2, 'firstName' => 'Peter', 'lastName' => 'Samuel', 'middleName' => '', 'terminationId' => null],
                 'reportingMethod' => ['id' => 1, 'name' => 'Direct']
             ],
             $result->normalize()
@@ -266,7 +266,8 @@ class EmployeeSubordinateAPITest extends EndpointTestCase
                         'empNumber' => 2,
                         'firstName' => 'Peter',
                         'lastName' => 'Samuel',
-                        'middleName' => ''
+                        'middleName' => '',
+                        "terminationId" => null
                     ],
                     'reportingMethod' => ['id' => 1, 'name' => 'Direct']
                 ],
@@ -275,7 +276,8 @@ class EmployeeSubordinateAPITest extends EndpointTestCase
                         'empNumber' => 3,
                         'firstName' => 'Andrew',
                         'lastName' => 'Daniel',
-                        'middleName' => ''
+                        'middleName' => '',
+                        "terminationId" => null
                     ],
                     'reportingMethod' => ['id' => 1, 'name' => 'Direct']
                 ]
@@ -358,7 +360,8 @@ class EmployeeSubordinateAPITest extends EndpointTestCase
                     "empNumber" => 2,
                     "firstName" => "Peter",
                     "lastName" => "Samuel",
-                    "middleName" => ""
+                    "middleName" => "",
+                    "terminationId" => null
                 ],
                 "reportingMethod" => [
                     "id" => 1,
@@ -495,7 +498,8 @@ class EmployeeSubordinateAPITest extends EndpointTestCase
                     "empNumber" => 2,
                     "firstName" => "Peter",
                     "lastName" => "Samuel",
-                    "middleName" => ""
+                    "middleName" => "",
+                    "terminationId" => null
                 ],
                 "reportingMethod" => [
                     "id" => 1,

--- a/symfony/plugins/orangehrmPimPlugin/test/Api/EmployeeSupervisorAPITest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/Api/EmployeeSupervisorAPITest.php
@@ -118,7 +118,7 @@ class EmployeeSupervisorAPITest extends EndpointTestCase
         $result = $api->getOne();
         $this->assertEquals(
             [
-                'supervisor' => ['empNumber' => 1, 'firstName' => 'Andrea', 'lastName' => 'Smith', 'middleName' => ''],
+                'supervisor' => ['empNumber' => 1, 'firstName' => 'Andrea', 'lastName' => 'Smith', 'middleName' => '', 'terminationId' => null],
                 'reportingMethod' => ['id' => 1, 'name' => 'Direct']
             ],
             $result->normalize()
@@ -267,7 +267,8 @@ class EmployeeSupervisorAPITest extends EndpointTestCase
                         'empNumber' => 1,
                         'firstName' => 'Andrea',
                         'lastName' => 'Smith',
-                        'middleName' => ''
+                        'middleName' => '',
+                        "terminationId" => null
                     ],
                     'reportingMethod' => ['id' => 1, 'name' => 'Direct']
                 ],
@@ -276,7 +277,8 @@ class EmployeeSupervisorAPITest extends EndpointTestCase
                         'empNumber' => 3,
                         'firstName' => 'Andrew',
                         'lastName' => 'Daniel',
-                        'middleName' => ''
+                        'middleName' => '',
+                        "terminationId" => null
                     ],
                     'reportingMethod' => ['id' => 1, 'name' => 'Direct']
                 ]
@@ -359,7 +361,8 @@ class EmployeeSupervisorAPITest extends EndpointTestCase
                     "empNumber" => 1,
                     "firstName" => "Andrea",
                     "lastName" => "Smith",
-                    "middleName" => ""
+                    "middleName" => "",
+                    "terminationId" => null
                 ],
                 "reportingMethod" => [
                     "id" => 1,
@@ -495,7 +498,8 @@ class EmployeeSupervisorAPITest extends EndpointTestCase
                     "empNumber" => 1,
                     "firstName" => "Andrea",
                     "lastName" => "Smith",
-                    "middleName" => ""
+                    "middleName" => "",
+                    "terminationId" => null
                 ],
                 "reportingMethod" => [
                     "id" => 1,

--- a/symfony/plugins/orangehrmPimPlugin/test/Api/Model/EmployeeSubordinateModelTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/Api/Model/EmployeeSubordinateModelTest.php
@@ -39,6 +39,7 @@ class EmployeeSubordinateModelTest extends TestCase
                 "firstName" => 'Andy',
                 "lastName" => "Smith",
                 "middleName" => "",
+                "terminationId" => null,
             ],
             "reportingMethod" => [
                 "id" => 1,
@@ -51,12 +52,14 @@ class EmployeeSubordinateModelTest extends TestCase
         $employee1->setLastName('Abbey');
         $employee1->setEmployeeId('0001');
         $employee1->setEmpNumber(1);
+        $employee1->setEmployeeTerminationRecord(null);
 
         $employee2 = new Employee();
         $employee2->setFirstName('Andy');
         $employee2->setLastName('Smith');
         $employee2->setEmployeeId('0002');
         $employee2->setEmpNumber(2);
+        $employee2->setEmployeeTerminationRecord(null);
 
         $reportingMethod = new ReportingMethod();
         $reportingMethod->setName('Direct');

--- a/symfony/plugins/orangehrmPimPlugin/test/Api/Model/EmployeeSupervisorModelTest.php
+++ b/symfony/plugins/orangehrmPimPlugin/test/Api/Model/EmployeeSupervisorModelTest.php
@@ -40,6 +40,7 @@ class EmployeeSupervisorModelTest extends TestCase
                 "firstName" => 'Kayla',
                 "lastName" => "Abbey",
                 "middleName" => "",
+                "terminationId" => null,
             ],
             "reportingMethod" => [
                 "id" => 1,
@@ -52,12 +53,14 @@ class EmployeeSupervisorModelTest extends TestCase
         $employee1->setLastName('Abbey');
         $employee1->setEmployeeId('0001');
         $employee1->setEmpNumber(1);
+        $employee1->setEmployeeTerminationRecord(null);
 
         $employee2 = new Employee();
         $employee2->setFirstName('Andy');
         $employee2->setLastName('Smith');
         $employee2->setEmployeeId('0002');
         $employee2->setEmpNumber(2);
+        $employee2->setEmployeeTerminationRecord(null);
 
         $reportingMethod = new ReportingMethod();
         $reportingMethod->setName('Direct');


### PR DESCRIPTION
This PR contains fixes for 

- OHRM5X-458
[PIM - Report to] Assign Supervisor/Subordinate field type should be similar to employee autocomplete field.

- OHRM5X-455
[PIM - Report to] Unable to search employees from their middle name.

- 