### PR TITLE
OHRM5X-456: [PIM - Report to] "Past employee" tag is not getting displayed next to the employee name of the terminated supervisors/subordinates

### DIFF
--- a/symfony/client/src/orangehrmPimPlugin/components/EmployeeSubordinates.vue
+++ b/symfony/client/src/orangehrmPimPlugin/components/EmployeeSubordinates.vue
@@ -82,7 +82,9 @@ import EditEmployeeReportTo from '@/orangehrmPimPlugin/components/EditEmployeeRe
 const subordinateNormalizer = data => {
   return data.map(item => {
     return {
-      name: `${item.subordinate?.firstName} ${item.subordinate?.lastName}`,
+      name: `${item.subordinate?.firstName} ${item.subordinate?.lastName} ${
+        item.subordinate.terminationId ? ' (Past Employee)' : ''
+      }`,
       reportingMethod: item.reportingMethod.name,
       subordinateEmpNumber: item.subordinate.empNumber,
     };

--- a/symfony/client/src/orangehrmPimPlugin/components/EmployeeSupervisors.vue
+++ b/symfony/client/src/orangehrmPimPlugin/components/EmployeeSupervisors.vue
@@ -82,7 +82,9 @@ import EditEmployeeReportTo from '@/orangehrmPimPlugin/components/EditEmployeeRe
 const supervisorNormalizer = data => {
   return data.map(item => {
     return {
-      name: `${item.supervisor?.firstName} ${item.supervisor?.lastName}`,
+      name: `${item.supervisor?.firstName} ${item.supervisor?.lastName} ${
+        item.supervisor.terminationId ? ' (Past Employee)' : ''
+      }`,
       reportingMethod: item.reportingMethod.name,
       supervisorEmpNumber: item.supervisor.empNumber,
     };


### PR DESCRIPTION
This PR contains the fix for following issue

- OHRM5X-456

[PIM - Report to] "Past employee" tag is not getting displayed next to the employee name of the terminated supervisors/subordinates

Backend change related to this fix is already done in this pull request https://github.com/orangehrm/orangehrm/pull/868