### PR TITLE
OHRM5X-802 [PIM] [Data Import] Incorrect toast message is displayed when a file with no records is uploaded

### DIFF
--- a/symfony/client/src/orangehrmPimPlugin/pages/dataImport/EmployeeDataImport.vue
+++ b/symfony/client/src/orangehrmPimPlugin/pages/dataImport/EmployeeDataImport.vue
@@ -103,7 +103,11 @@
 
 <script>
 import {APIService} from '@/core/util/services/api.service';
-import {required, maxFileSize, validFileTypes} from "@/core/util/validation/rules";
+import {
+  required,
+  maxFileSize,
+  validFileTypes,
+} from '@/core/util/validation/rules';
 
 const attachmentModel = {
   attachment: null,
@@ -127,7 +131,7 @@ export default {
         attachment: [
           required,
           maxFileSize(1048576),
-          validFileTypes(this.allowedFileTypes)
+          validFileTypes(this.allowedFileTypes),
         ],
       },
     };


### PR DESCRIPTION
This PR fixes the following issues with the same fix. Two eslint warnings were also fixed.

* OHRM5X-801
[PIM] [Data Import] Incorrect toast message is displayed when a file with no first names /last names are uploaded
* OHRM5X-802
[PIM] [Data Import] Incorrect toast message is displayed when a file with no records is uploaded
* OHRM5X-764
[PIM] [Data Import] Success toast is shown when a csv file with interchanged columns are uploaded