### PR TITLE
OHRM5X-960: Paygrade broken defect fixes added

### DIFF
--- a/symfony/client/src/core/util/validation/__tests__/rules.spec.ts
+++ b/symfony/client/src/core/util/validation/__tests__/rules.spec.ts
@@ -403,4 +403,14 @@ describe('core/util/validation/rules::minValueShouldBeLowerThanMaxValue', () => 
     )('101');
     expect(result).toEqual(true);
   });
+
+  test('minValueShouldBeLowerThanMaxValue:: should allow minimum and maximum value as zero', () => {
+    const result = minValueShouldBeLowerThanMaxValue('0', undefined)('0');
+    expect(result).toEqual(true);
+  });
+
+  test('minValueShouldBeLowerThanMaxValue:: should allow minimum and maximum value as empty string literal', () => {
+    const result = minValueShouldBeLowerThanMaxValue('', undefined)('');
+    expect(result).toEqual(true);
+  });
 });

--- a/symfony/client/src/core/util/validation/rules.ts
+++ b/symfony/client/src/core/util/validation/rules.ts
@@ -433,6 +433,10 @@ export const minValueShouldBeLowerThanMaxValue = (
       typeof message === 'string'
         ? message
         : 'Should be higher than Minimum Value';
+    if (resolvedMinValue === null || value === null) return true;
+    if (resolvedMinValue === undefined || value === undefined) return true;
+    if (resolvedMinValue === '' || value === '') return true;
+    if (resolvedMinValue === '0' || value === '0') return true;
     return parseFloat(resolvedMinValue) < parseFloat(value) || resolvedMessage;
   };
 };

--- a/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/EditPayCurrency.vue
+++ b/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/EditPayCurrency.vue
@@ -108,7 +108,7 @@ export default {
       payCurrency: {...payCurrencyModel},
       rules: {
         currencyId: [required],
-        minSalary: [maxCurrency(1000000000)],
+        minSalary: [maxCurrency(1000000000), digitsOnly],
         maxSalary: [
           maxCurrency(1000000000),
           digitsOnly,

--- a/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/EditPayCurrency.vue
+++ b/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/EditPayCurrency.vue
@@ -78,7 +78,7 @@ import {
   minValueShouldBeLowerThanMaxValue,
 } from '@ohrm/core/util/validation/rules';
 const payCurrencyModel = {
-  currencyId: '',
+  currencyId: null,
   minSalary: '',
   maxSalary: '',
 };
@@ -108,7 +108,7 @@ export default {
       payCurrency: {...payCurrencyModel},
       rules: {
         currencyId: [required],
-        minSalary: [maxCurrency(1000000000), digitsOnly],
+        minSalary: [maxCurrency(1000000000)],
         maxSalary: [
           maxCurrency(1000000000),
           digitsOnly,
@@ -127,8 +127,8 @@ export default {
       .then(response => {
         const {data} = response.data;
         this.payCurrency.name = data.currencyType.name;
-        this.payCurrency.minSalary = data.minSalary;
-        this.payCurrency.maxSalary = data.maxSalary;
+        this.payCurrency.minSalary = data.minSalary ? data.minSalary : '0';
+        this.payCurrency.maxSalary = data.maxSalary ? data.maxSalary : '0';
       })
       .finally(() => {
         this.isLoading = false;

--- a/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/PayGradeCurrency.vue
+++ b/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/PayGradeCurrency.vue
@@ -77,8 +77,12 @@ const PayGradeCurrencyNormalizer = data => {
     return {
       id: item.currencyType.id,
       name: item.currencyType.name,
-      maxSalary: item.maxSalary,
-      minSalary: item.minSalary,
+      maxSalary: item.maxSalary
+        ? parseFloat(item.maxSalary).toFixed(2)
+        : '0.00',
+      minSalary: item.minSalary
+        ? parseFloat(item.minSalary).toFixed(2)
+        : '0.00',
     };
   });
 };

--- a/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/SavePayCurrency.vue
+++ b/symfony/client/src/orangehrmAdminPlugin/pages/payGrade/SavePayCurrency.vue
@@ -79,7 +79,7 @@ import {
 } from '@ohrm/core/util/validation/rules';
 import {minValueShouldBeLowerThanMaxValue} from '@/core/util/validation/rules';
 const payCurrencyModel = {
-  currencyId: '',
+  currencyId: null,
   minSalary: '',
   maxSalary: '',
 };


### PR DESCRIPTION
This PR Contains following fixes:
1. OHRM5X-960 : [Pay Grades] [Broken]User is not able to add a currency without minimum and maximum salary.