### PR TITLE
OHRM5X-979: Create database snapshot & restore while test automation

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Run tests
         run: |
+          docker exec os_dev_php80 bash -c 'php symfony/test/functional/tools/prepare.php'
           cd html/symfony/test/functional
           sed -i 's~http://php80/orangehrm/web/index.php~http://php80/web/index.php~g' cypress.json
           sed -i 's~false~true~g' cypress.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ apidoc
 logInsatall.log
 .phpunit.result.cache
 coverage/
-symfony/test/functional/cypress/fixtures/admin.json
+symfony/plugins/orangehrmFunctionalTestingPlugin
 .php-cs-fixer.cache
 .php-cs-fixer.php

--- a/symfony/plugins/orangehrmAuthenticationPlugin/Subscriber/AuthenticationSubscriber.php
+++ b/symfony/plugins/orangehrmAuthenticationPlugin/Subscriber/AuthenticationSubscriber.php
@@ -51,7 +51,7 @@ class AuthenticationSubscriber extends AbstractEventSubscriber
     {
         return [
             KernelEvents::REQUEST => [
-                ['onRequestEvent', 99000],
+                ['onRequestEvent', 98000],
             ],
             KernelEvents::CONTROLLER => [
                 ['onControllerEvent', 100000],

--- a/symfony/test/functional/cypress/integration/orangehrm/admin/jobtitle.spec.js
+++ b/symfony/test/functional/cypress/integration/orangehrm/admin/jobtitle.spec.js
@@ -1,11 +1,16 @@
 import user from '../../../fixtures/admin-user.json';
 
 describe('Job title page', function () {
+  beforeEach(() => {
+    cy.truncateTable(['JobTitle']);
+  });
+
   it('Check job title view page', () => {
-    cy.login(user.admin.userName, user.admin.password);
-
-    cy.visit('/admin/viewJobTitleList');
-
+    cy.loginTo(
+      user.admin.userName,
+      user.admin.password,
+      '/admin/viewJobTitleList',
+    );
     cy.get('.orangehrm-main-title').should('include.text', 'Job Title');
   });
 });

--- a/symfony/test/functional/cypress/integration/orangehrm/core/login.spec.js
+++ b/symfony/test/functional/cypress/integration/orangehrm/core/login.spec.js
@@ -1,28 +1,13 @@
 import user from '../../../fixtures/admin-user.json';
 
-describe('Automation Test Suite - Fixtures', function () {
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('Visits the login page', () => {
-    cy.visit('/auth/login');
-
-    cy.get('input[name=username]').type(user.admin.userName);
-
-    cy.get('input[name=password]').type(user.admin.password);
-
-    cy.get('form').submit();
-
+describe('Login page', () => {
+  it('Visits the login page', () => {
+    cy.login(user.admin.userName, user.admin.password);
     cy.get('.oxd-userdropdown').should('include.text', user.admin.fullName);
   });
 
   it('Visits the login page and check validations', () => {
-    cy.visit('/auth/login');
-
-    cy.get('input[name=username]').type(' ');
-
-    cy.get('input[name=password]').type(' ');
-
-    cy.get('form').submit();
-
+    cy.login(' ', ' ');
     cy.get('.oxd-text').should('include.text', 'Required');
   });
 });

--- a/symfony/test/functional/cypress/support/commands.js
+++ b/symfony/test/functional/cypress/support/commands.js
@@ -26,11 +26,8 @@
 
 Cypress.Commands.add('login', (username, password) => {
   cy.visit('/auth/login');
-
   cy.get('input[name=username]').type(username);
-
   cy.get('input[name=password]').type(password);
-
   cy.get('form').submit();
 });
 
@@ -43,3 +40,11 @@ Cypress.Commands.add(
     cy.get('form').submit();
   },
 );
+
+Cypress.Commands.add('truncateTable', (tables = []) => {
+  cy.request({
+    url: '/functional-testing/truncate-table',
+    method: 'POST',
+    body: {tables},
+  });
+});

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/AbstractController.php
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/AbstractController.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA
+ */
+
+namespace OrangeHRM\FunctionalTesting\Controller;
+
+use OrangeHRM\Framework\Http\RedirectResponse;
+use OrangeHRM\Framework\Http\Response;
+use OrangeHRM\FunctionalTesting\Service\DatabaseBackupService;
+
+class AbstractController extends \OrangeHRM\Core\Controller\AbstractController
+{
+    private ?DatabaseBackupService $databaseBackupService = null;
+
+    /**
+     * @return DatabaseBackupService
+     */
+    public function getDatabaseBackupService(): DatabaseBackupService
+    {
+        if (!$this->databaseBackupService instanceof DatabaseBackupService) {
+            $this->databaseBackupService = new DatabaseBackupService();
+        }
+        return $this->databaseBackupService;
+    }
+
+    /**
+     * @return RedirectResponse|Response
+     */
+    protected function getResponse()
+    {
+        $response = parent::getResponse();
+        $response->headers->set(
+            \OrangeHRM\Core\Api\V2\Response::CONTENT_TYPE_KEY,
+            \OrangeHRM\Core\Api\V2\Response::CONTENT_TYPE_JSON
+        );
+        return $response;
+    }
+}

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/ResetDatabaseController.php
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/ResetDatabaseController.php
@@ -17,38 +17,24 @@
  * Boston, MA  02110-1301, USA
  */
 
-namespace OrangeHRM\Core\Subscriber;
+namespace OrangeHRM\FunctionalTesting\Controller;
 
-use OrangeHRM\Framework\Event\AbstractEventSubscriber;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
+use OrangeHRM\Core\Controller\PublicControllerInterface;
+use OrangeHRM\Framework\Http\Request;
+use OrangeHRM\Framework\Http\Response;
+use OrangeHRM\FunctionalTesting\Service\DatabaseBackupService;
 
-class RequestBodySubscriber extends AbstractEventSubscriber
+class ResetDatabaseController extends AbstractController implements PublicControllerInterface
 {
     /**
-     * @inheritDoc
+     * @param Request $request
+     * @return Response
      */
-    public static function getSubscribedEvents(): array
+    public function handle(Request $request): Response
     {
-        return [
-            KernelEvents::REQUEST => [
-                ['onRequestEvent', 99000],
-            ],
-        ];
-    }
-
-    public function onRequestEvent(RequestEvent $event)
-    {
-        $request = $event->getRequest();
-
-        // 'application/json', 'application/x-json'
-        if ($request->getContentType() === 'json') {
-            if ($request->getContent() !== '') {
-                $data = json_decode($request->getContent(), true);
-                if (is_array($data)) {
-                    $request->request->add($data);
-                }
-            }
-        }
+        $tables = $this->getDatabaseBackupService()->restoreToSavepoint(DatabaseBackupService::INITIAL_SAVEPOINT_NAME);
+        $response = $this->getResponse();
+        $response->setContent(json_encode(['count' => count($tables)]));
+        return $response;
     }
 }

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/RestoreDatabaseToSavepointController.php
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/RestoreDatabaseToSavepointController.php
@@ -17,38 +17,24 @@
  * Boston, MA  02110-1301, USA
  */
 
-namespace OrangeHRM\Core\Subscriber;
+namespace OrangeHRM\FunctionalTesting\Controller;
 
-use OrangeHRM\Framework\Event\AbstractEventSubscriber;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
+use OrangeHRM\Core\Controller\PublicControllerInterface;
+use OrangeHRM\Framework\Http\Request;
+use OrangeHRM\Framework\Http\Response;
 
-class RequestBodySubscriber extends AbstractEventSubscriber
+class RestoreDatabaseToSavepointController extends AbstractController implements PublicControllerInterface
 {
     /**
-     * @inheritDoc
+     * @param Request $request
+     * @return Response
      */
-    public static function getSubscribedEvents(): array
+    public function handle(Request $request): Response
     {
-        return [
-            KernelEvents::REQUEST => [
-                ['onRequestEvent', 99000],
-            ],
-        ];
-    }
-
-    public function onRequestEvent(RequestEvent $event)
-    {
-        $request = $event->getRequest();
-
-        // 'application/json', 'application/x-json'
-        if ($request->getContentType() === 'json') {
-            if ($request->getContent() !== '') {
-                $data = json_decode($request->getContent(), true);
-                if (is_array($data)) {
-                    $request->request->add($data);
-                }
-            }
-        }
+        $savepointName = $request->request->get('savepointName');
+        $tables = $this->getDatabaseBackupService()->restoreToSavepoint($savepointName);
+        $response = $this->getResponse();
+        $response->setContent(json_encode(['count' => count($tables)]));
+        return $response;
     }
 }

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/TruncateTableController.php
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Controller/TruncateTableController.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA
+ */
+
+namespace OrangeHRM\FunctionalTesting\Controller;
+
+use OrangeHRM\Core\Controller\AbstractController;
+use OrangeHRM\Core\Controller\PublicControllerInterface;
+use OrangeHRM\Framework\Http\Request;
+use OrangeHRM\Framework\Http\Response;
+use OrangeHRM\Tests\Util\TestDataService;
+
+class TruncateTableController extends AbstractController implements PublicControllerInterface
+{
+    /**
+     * @param Request $request
+     * @return Response
+     */
+    public function handle(Request $request): Response
+    {
+        $tables = $request->request->get('tables', []);
+        TestDataService::truncateSpecificTables($tables);
+        return $this->getResponse();
+    }
+}

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Service/DatabaseBackupService.php
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/Service/DatabaseBackupService.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA
+ */
+
+namespace OrangeHRM\FunctionalTesting\Service;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Exception;
+use OrangeHRM\Core\Traits\CacheTrait;
+use OrangeHRM\Core\Traits\ORM\EntityManagerHelperTrait;
+use Symfony\Component\Cache\CacheItem;
+
+class DatabaseBackupService
+{
+    use EntityManagerHelperTrait;
+    use CacheTrait;
+
+    public const DB_SAVEPOINT_CACHE_KEY_PREFIX = 'db.savepoint';
+    public const INITIAL_SAVEPOINT_NAME = '__initial';
+
+    /**
+     * @return Connection
+     */
+    private function getConnection(): Connection
+    {
+        $conn = $this->getEntityManager()->getConnection();
+        $conn->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        return $conn;
+    }
+
+    /**
+     * @return AbstractSchemaManager
+     */
+    private function getSchemaManager(): AbstractSchemaManager
+    {
+        $conn = $this->getConnection();
+        return $conn->createSchemaManager();
+    }
+
+    /**
+     * @param string $savepointName
+     * @param string|null $tableName
+     * @return string
+     */
+    private function genSavepointCacheKey(string $savepointName, ?string $tableName): string
+    {
+        return self::DB_SAVEPOINT_CACHE_KEY_PREFIX . ".$savepointName.$tableName";
+    }
+
+    /**
+     * @param string $savepointName
+     * @return array
+     */
+    public function createSavepoint(string $savepointName): array
+    {
+        if ($savepointName === self::INITIAL_SAVEPOINT_NAME) {
+            throw new Exception('Not allowed to use reserved savepoint name');
+        }
+        return $this->_createSavepoint($savepointName);
+    }
+
+    /**
+     * @return array
+     */
+    public function createInitialSavepoint(): array
+    {
+        return $this->_createSavepoint(self::INITIAL_SAVEPOINT_NAME);
+    }
+
+    /**
+     * @param string $savepointName
+     * @return array
+     */
+    private function _createSavepoint(string $savepointName): array
+    {
+        $conn = $this->getConnection();
+
+        $tables = [];
+        $allTables = $this->getSchemaManager()->listTables();
+        foreach ($allTables as $table) {
+            $tableName = $table->getName();
+            $results = $conn->fetchAllAssociative("SELECT * FROM `$tableName`");
+
+            /** @var CacheItem $cacheItem */
+            $cacheItem = $this->getCache()->getItem($this->genSavepointCacheKey($savepointName, $tableName));
+            if ($cacheItem->isHit()) {
+                throw new Exception('Savepoint already created for the given name');
+            }
+
+            $this->getCache()->get(
+                $this->genSavepointCacheKey($savepointName, $tableName),
+                function () use ($tableName, $results) {
+                    return ['tableName' => $tableName, 'data' => $results];
+                }
+            );
+
+            $tables[] = $table;
+        }
+        if (count($allTables) !== count($tables)) {
+            throw new Exception('Incomplete savepoint creation');
+        }
+        return $tables;
+    }
+
+    /**
+     * @param string $savepointName
+     * @return array
+     */
+    public function restoreToSavepoint(string $savepointName): array
+    {
+        $conn = $this->getConnection();
+        $conn->executeStatement('SET FOREIGN_KEY_CHECKS=0;');
+        $this->beginTransaction();
+        try {
+            $tables = [];
+            $allTables = $this->getSchemaManager()->listTables();
+            foreach ($allTables as $table) {
+                $tableName = $table->getName();
+                /** @var CacheItem $cacheItem */
+                $cacheItem = $this->getCache()->getItem($this->genSavepointCacheKey($savepointName, $tableName));
+                if (!$cacheItem->isHit()) {
+                    throw new Exception('No savepoint for the given name');
+                }
+
+                $conn->executeStatement("TRUNCATE TABLE `$tableName`");
+                $data = $cacheItem->get()['data'];
+                foreach ($data as $row) {
+                    $conn->insert($tableName, $row);
+                }
+                $tables[] = [$table, count($data)];
+            }
+            $this->commitTransaction();
+            $conn->getWrappedConnection()->exec('SET FOREIGN_KEY_CHECKS=1;');
+
+            return $tables;
+        } catch (Exception $e) {
+            $this->rollBackTransaction();
+            $conn->executeStatement('SET FOREIGN_KEY_CHECKS=1;');
+            throw $e;
+        }
+    }
+
+    /**
+     * @param string $savepointName
+     * @return bool
+     */
+    public function deleteSavepoint(string $savepointName): bool
+    {
+        if ($savepointName === self::INITIAL_SAVEPOINT_NAME) {
+            throw new Exception('Not allowed to delete reserved savepoint name');
+        }
+        return $this->_deleteSavepoint($savepointName);
+    }
+
+    /**
+     * @param string $savepointName
+     * @return bool
+     */
+    private function _deleteSavepoint(string $savepointName): bool
+    {
+        return $this->getCache()->clear($this->genSavepointCacheKey($savepointName, null));
+    }
+}

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/config/FunctionalTestingPluginConfiguration.php
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/config/FunctionalTestingPluginConfiguration.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA
+ */
+
+use Composer\Autoload\ClassLoader;
+use OrangeHRM\Framework\Http\Request;
+use OrangeHRM\Framework\PluginConfigurationInterface;
+
+class FunctionalTestingPluginConfiguration implements PluginConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function initialize(Request $request): void
+    {
+        $loader = new ClassLoader();
+        $loader->addPsr4('OrangeHRM\\FunctionalTesting\\', [realpath(__DIR__ . '/..')]);
+        $loader->register();
+    }
+}

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/config/routes.yaml
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/config/routes.yaml
@@ -2,3 +2,18 @@ functional_testing_truncate_table:
   path: /functional-testing/truncate-table
   controller: OrangeHRM\FunctionalTesting\Controller\TruncateTableController::handle
   methods: [ POST ]
+
+functional_testing_reset_database:
+  path: /functional-testing/database/reset
+  controller: OrangeHRM\FunctionalTesting\Controller\ResetDatabaseController::handle
+  methods: [ POST ]
+
+functional_testing_create_db_savepoint:
+  path: /functional-testing/database/create-savepoint
+  controller: OrangeHRM\FunctionalTesting\Controller\CreateDatabaseSavepointController::handle
+  methods: [ POST ]
+
+functional_testing_restore_db_to_savepoint:
+  path: /functional-testing/database/restore-to-savepoint
+  controller: OrangeHRM\FunctionalTesting\Controller\RestoreDatabaseToSavepointController::handle
+  methods: [ POST ]

--- a/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/config/routes.yaml
+++ b/symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin/config/routes.yaml
@@ -1,0 +1,4 @@
+functional_testing_truncate_table:
+  path: /functional-testing/truncate-table
+  controller: OrangeHRM\FunctionalTesting\Controller\TruncateTableController::handle
+  methods: [ POST ]

--- a/symfony/test/functional/tools/prepare.php
+++ b/symfony/test/functional/tools/prepare.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA
+ */
+
+use OrangeHRM\Config\Config;
+
+require realpath(__DIR__ . '/../../../vendor/autoload.php');
+
+if (Config::PRODUCT_MODE === Config::MODE_PROD) {
+    echo "Not allowed to execute in prod mode`\n";
+    exit;
+}
+$filesystem = new Symfony\Component\Filesystem\Filesystem();
+$filesystem->symlink(
+    realpath(__DIR__ . '/plugins/orangehrmFunctionalTestingPlugin'),
+    Config::get(Config::PLUGINS_DIR) . '/orangehrmFunctionalTestingPlugin',
+    true
+);
+echo 'Successfully copied `symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin` ' .
+    "to symfony/plugins/orangehrmFunctionalTestingPlugin\n";

--- a/symfony/test/functional/tools/prepare.php
+++ b/symfony/test/functional/tools/prepare.php
@@ -17,7 +17,13 @@
  * Boston, MA  02110-1301, USA
  */
 
+use Composer\Autoload\ClassLoader;
 use OrangeHRM\Config\Config;
+use OrangeHRM\Core\Service\CacheService;
+use OrangeHRM\Framework\ServiceContainer;
+use OrangeHRM\Framework\Services;
+use OrangeHRM\FunctionalTesting\Service\DatabaseBackupService;
+use OrangeHRM\ORM\Doctrine;
 
 require realpath(__DIR__ . '/../../../vendor/autoload.php');
 
@@ -31,5 +37,14 @@ $filesystem->symlink(
     Config::get(Config::PLUGINS_DIR) . '/orangehrmFunctionalTestingPlugin',
     true
 );
-echo 'Successfully copied `symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin` ' .
+echo "\nSuccessfully copied `symfony/test/functional/tools/plugins/orangehrmFunctionalTestingPlugin` " .
     "to symfony/plugins/orangehrmFunctionalTestingPlugin\n";
+
+$loader = new ClassLoader();
+$loader->addPsr4('OrangeHRM\\FunctionalTesting\\', [realpath(__DIR__ . '/plugins/orangehrmFunctionalTestingPlugin')]);
+$loader->register();
+ServiceContainer::getContainer()->register(Services::CACHE)->setFactory([CacheService::class, 'getCache']);
+ServiceContainer::getContainer()->register(Services::DOCTRINE)->setFactory([Doctrine::class, 'getEntityManager']);
+$databaseBackupService = new DatabaseBackupService();
+$databaseBackupService->createInitialSavepoint();
+echo "\nCreated initial savepoint for the database\n";

--- a/symfony/test/functional/tools/teardown.php
+++ b/symfony/test/functional/tools/teardown.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software; you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA
+ */
+
+use OrangeHRM\Config\Config;
+
+require realpath(__DIR__ . '/../../../vendor/autoload.php');
+
+if (Config::PRODUCT_MODE === Config::MODE_PROD) {
+    echo "Not allowed to execute in prod mode`\n";
+    exit;
+}
+$filesystem = new Symfony\Component\Filesystem\Filesystem();
+$filesystem->remove([Config::get(Config::PLUGINS_DIR) . '/orangehrmFunctionalTestingPlugin']);
+echo "Successfully deleted `symfony/plugins/orangehrmFunctionalTestingPlugin`\n";

--- a/symfony/test/functional/tools/teardown.php
+++ b/symfony/test/functional/tools/teardown.php
@@ -27,4 +27,4 @@ if (Config::PRODUCT_MODE === Config::MODE_PROD) {
 }
 $filesystem = new Symfony\Component\Filesystem\Filesystem();
 $filesystem->remove([Config::get(Config::PLUGINS_DIR) . '/orangehrmFunctionalTestingPlugin']);
-echo "Successfully deleted `symfony/plugins/orangehrmFunctionalTestingPlugin`\n";
+echo "\nSuccessfully deleted `symfony/plugins/orangehrmFunctionalTestingPlugin`\n";


### PR DESCRIPTION
Exposed public APIs for Cypress testing
- `{{base_url}}/functional-testing/truncate-table` this API can remove
- `{{base_url}}/functional-testing/database/reset`
- `{{base_url}}/functional-testing/database/create-savepoint`
- `{{base_url}}/functional-testing/database/restore-to-savepoint`