### PR TITLE
OHRM5X-1154: Attendance module bug fixes added

### DIFF
--- a/symfony/plugins/orangehrmAttendancePlugin/Controller/ViewEmployeeAttendanceController.php
+++ b/symfony/plugins/orangehrmAttendancePlugin/Controller/ViewEmployeeAttendanceController.php
@@ -59,7 +59,7 @@ class ViewEmployeeAttendanceController extends AbstractVueController
 
             if (
                 $this->getAttendanceService()->canSupervisorModifyAttendanceConfiguration()
-                && $this->getAuthUser()->getUserRoleName() === 'Admin'
+                && $this->getAuthUser()->getEmpNumber() !== $empNumber
             ) {
                 $component->addProp(new Prop('is-editable', Prop::TYPE_BOOLEAN, true));
             }

--- a/symfony/plugins/orangehrmAttendancePlugin/Controller/ViewEmployeeAttendanceController.php
+++ b/symfony/plugins/orangehrmAttendancePlugin/Controller/ViewEmployeeAttendanceController.php
@@ -59,7 +59,7 @@ class ViewEmployeeAttendanceController extends AbstractVueController
 
             if (
                 $this->getAttendanceService()->canSupervisorModifyAttendanceConfiguration()
-                && $this->getAuthUser()->getEmpNumber() !== $empNumber
+                && $this->getAuthUser()->getUserRoleName() === 'Admin'
             ) {
                 $component->addProp(new Prop('is-editable', Prop::TYPE_BOOLEAN, true));
             }

--- a/symfony/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
+++ b/symfony/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
@@ -351,12 +351,12 @@ class AttendanceDao extends BaseDao
 
         $this->setSortingAndPaginationParams($q, $attendanceReportSearchFilterParams);
 
-        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())){
+        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())) {
             // both from date and to date is null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord');
         }
 
-        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())){
+        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())) {
             // from date is not null and to date is null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
                 $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate')
@@ -364,7 +364,7 @@ class AttendanceDao extends BaseDao
             $q->setParameter('fromDate', $attendanceReportSearchFilterParams->getFromDate());
         }
 
-        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())){
+        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())) {
             // from date is null and to date is not null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
                 $q->expr()->lte('attendanceRecord.punchOutUserTime', ':toDate')
@@ -372,7 +372,7 @@ class AttendanceDao extends BaseDao
             $q->setParameter('toDate', $attendanceReportSearchFilterParams->getToDate());
         }
 
-        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())){
+        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())) {
             // both from date and to date is not null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
                 $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate'),

--- a/symfony/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
+++ b/symfony/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
@@ -348,9 +348,39 @@ class AttendanceDao extends BaseDao
         $q->leftJoin('employee.jobTitle', 'jobTitle');
         $q->leftJoin('employee.subDivision', 'subunit');
         $q->leftJoin('employee.empStatus', 'empStatus');
-        $q->leftJoin('employee.attendanceRecords', 'attendanceRecord');
 
         $this->setSortingAndPaginationParams($q, $attendanceReportSearchFilterParams);
+
+        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())){
+            // both from date and to date is null
+            $q->leftJoin('employee.attendanceRecords', 'attendanceRecord');
+        }
+
+        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())){
+            // from date is not null and to date is null
+            $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
+                $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate')
+            ));
+            $q->setParameter('fromDate', $attendanceReportSearchFilterParams->getFromDate());
+        }
+
+        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())){
+            // from date is null and to date is not null
+            $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
+                $q->expr()->lte('attendanceRecord.punchOutUserTime', ':toDate')
+            ));
+            $q->setParameter('toDate', $attendanceReportSearchFilterParams->getToDate());
+        }
+
+        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())){
+            // both from date and to date is not null
+            $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
+                $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate'),
+                $q->expr()->lte('attendanceRecord.punchOutUserTime', ':toDate')
+            ));
+            $q->setParameter('fromDate', $attendanceReportSearchFilterParams->getFromDate());
+            $q->setParameter('toDate', $attendanceReportSearchFilterParams->getToDate());
+        }
 
         if (!is_null($attendanceReportSearchFilterParams->getEmployeeNumbers())) {
             $q->andWhere($q->expr()->in('employee.empNumber', ':empNumbers'))
@@ -370,23 +400,6 @@ class AttendanceDao extends BaseDao
         if (!is_null($attendanceReportSearchFilterParams->getEmploymentStatusId())) {
             $q->andWhere('empStatus.id = :empStatusId')
                 ->setParameter('empStatusId', $attendanceReportSearchFilterParams->getEmploymentStatusId());
-        }
-
-        if (!is_null($attendanceReportSearchFilterParams->getFromDate())) {
-            $q->andWhere($q->expr()->orX(
-                $q->expr()->isNull('attendanceRecord.id'),
-                $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate')
-            ))
-                ->setParameter('fromDate', $attendanceReportSearchFilterParams->getFromDate());
-        }
-
-        if (!is_null($attendanceReportSearchFilterParams->getToDate())) {
-            $q->andWhere($q->expr()->orX(
-                $q->expr()->isNull('attendanceRecord.id'),
-                $q->expr()->isNull('attendanceRecord.punchOutUserTime'),
-                $q->expr()->lte('attendanceRecord.punchOutUserTime', ':toDate')
-            ))
-                ->setParameter('toDate', $attendanceReportSearchFilterParams->getToDate());
         }
 
         return $this->getQueryBuilderWrapper($q);

--- a/symfony/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
+++ b/symfony/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
@@ -354,25 +354,19 @@ class AttendanceDao extends BaseDao
         if (is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())) {
             // both from date and to date is null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord');
-        }
-
-        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())) {
+        } elseif (!is_null($attendanceReportSearchFilterParams->getFromDate()) && is_null($attendanceReportSearchFilterParams->getToDate())) {
             // from date is not null and to date is null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
                 $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate')
             ));
             $q->setParameter('fromDate', $attendanceReportSearchFilterParams->getFromDate());
-        }
-
-        if (is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())) {
+        } elseif (is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())) {
             // from date is null and to date is not null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
                 $q->expr()->lte('attendanceRecord.punchOutUserTime', ':toDate')
             ));
             $q->setParameter('toDate', $attendanceReportSearchFilterParams->getToDate());
-        }
-
-        if (!is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())) {
+        } elseif (!is_null($attendanceReportSearchFilterParams->getFromDate()) && !is_null($attendanceReportSearchFilterParams->getToDate())) {
             // both from date and to date is not null
             $q->leftJoin('employee.attendanceRecords', 'attendanceRecord', Expr\Join::WITH, $q->expr()->andX(
                 $q->expr()->gte('attendanceRecord.punchInUserTime', ':fromDate'),

--- a/symfony/plugins/orangehrmTimePlugin/Report/AttendanceReport.php
+++ b/symfony/plugins/orangehrmTimePlugin/Report/AttendanceReport.php
@@ -19,6 +19,7 @@
 
 namespace OrangeHRM\Time\Report;
 
+use DateTime;
 use OrangeHRM\Core\Api\V2\Exception\ForbiddenException;
 use OrangeHRM\Core\Api\V2\RequestParams;
 use OrangeHRM\Core\Api\V2\Validator\ParamRule;
@@ -99,18 +100,26 @@ class AttendanceReport implements EndpointAwareReport
                 self::FILTER_EMPLOYMENT_STATUS_ID
             )
         );
-        $filterParams->setFromDate(
-            $endpoint->getRequestParams()->getDateTimeOrNull(
+
+        $filterParams->setEmploymentStatusId(
+            $endpoint->getRequestParams()->getIntOrNull(
                 RequestParams::PARAM_TYPE_QUERY,
-                self::FILTER_PARAMETER_DATE_FROM
+                self::FILTER_EMPLOYMENT_STATUS_ID
             )
         );
-        $filterParams->setToDate(
-            $endpoint->getRequestParams()->getDateTimeOrNull(
-                RequestParams::PARAM_TYPE_QUERY,
-                self::FILTER_PARAMETER_DATE_TO
-            )
+
+        $fromDate = $endpoint->getRequestParams()->getStringOrNull(
+            RequestParams::PARAM_TYPE_QUERY,
+            self::FILTER_PARAMETER_DATE_FROM
         );
+
+        $toDate = $endpoint->getRequestParams()->getStringOrNull(
+            RequestParams::PARAM_TYPE_QUERY,
+            self::FILTER_PARAMETER_DATE_TO
+        );
+
+        $filterParams->setFromDate($fromDate ? new DateTime($fromDate . ' ' . '00:00:00') : null);
+        $filterParams->setToDate($toDate ? new DateTime($toDate . ' ' . '23:59:59') : null);
 
         return $filterParams;
     }
@@ -178,8 +187,8 @@ class AttendanceReport implements EndpointAwareReport
                 )
             ),
             ...$endpoint->getSortingAndPaginationParamsRules(
-                AttendanceReportSearchFilterParams::ALLOWED_SORT_FIELDS
-            )
+            AttendanceReportSearchFilterParams::ALLOWED_SORT_FIELDS
+        )
         );
     }
 

--- a/symfony/plugins/orangehrmTimePlugin/Report/AttendanceReport.php
+++ b/symfony/plugins/orangehrmTimePlugin/Report/AttendanceReport.php
@@ -187,8 +187,8 @@ class AttendanceReport implements EndpointAwareReport
                 )
             ),
             ...$endpoint->getSortingAndPaginationParamsRules(
-            AttendanceReportSearchFilterParams::ALLOWED_SORT_FIELDS
-        )
+                AttendanceReportSearchFilterParams::ALLOWED_SORT_FIELDS
+            )
         );
     }
 

--- a/symfony/plugins/orangehrmTimePlugin/test/Api/AttendanceReportDataAPITest.php
+++ b/symfony/plugins/orangehrmTimePlugin/test/Api/AttendanceReportDataAPITest.php
@@ -32,13 +32,21 @@ use OrangeHRM\Time\Api\TimeReportDataAPI;
  */
 class AttendanceReportDataAPITest extends EndpointIntegrationTestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        TestDataService::populate(Config::get(Config::TEST_DIR) . '/phpunit/fixtures/DataGroupPermission.yaml', true);
+        TestDataService::populate(
+            Config::get(Config::PLUGINS_DIR) .
+            '/orangehrmTimePlugin/test/fixtures/AttendanceReportDataAPITest.yaml',
+            true
+        );
+    }
+
     /**
      * @dataProvider dataProviderForTestGetAll
      */
     public function testGetAll(TestCaseParams $testCaseParams): void
     {
-        TestDataService::populate(Config::get(Config::TEST_DIR) . '/phpunit/fixtures/DataGroupPermission.yaml', true);
-        $this->populateFixtures('AttendanceReportDataAPITest.yaml', null, true);
         $this->createKernelWithMockServices([Services::AUTH_USER => $this->getMockAuthUser($testCaseParams)]);
         $this->registerServices($testCaseParams);
         $this->registerMockDateTimeHelper($testCaseParams);

--- a/symfony/plugins/orangehrmTimePlugin/test/fixtures/testcases/AttendanceReportDataAPITestCase.yaml
+++ b/symfony/plugins/orangehrmTimePlugin/test/fixtures/testcases/AttendanceReportDataAPITestCase.yaml
@@ -79,11 +79,27 @@ GetAll:
         "time": "9.00"
       },
       {
+        "employeeName": "Ashley Abel",
+        "time": "0.00"
+      },
+      {
+        "employeeName": "mahatma gandhi",
+        "time": "0.00"
+      },
+      {
+        "employeeName": "Adolf Hitler",
+        "time": "0.00"
+      },
+      {
         "employeeName": "Vladimir Lenin",
         "time": "0.00"
       },
       {
         "employeeName": "Benito Mussolini (Past employee)",
+        "time": "0.00"
+      },
+      {
+        "employeeName": "Renukshan Saputhanthri",
         "time": "0.00"
       },
       {
@@ -93,10 +109,14 @@ GetAll:
       {
         "employeeName": "Tony Stark",
         "time": "0.00"
+      },
+      {
+        "employeeName": "mother teresa",
+        "time": "0.00"
       }
     ]
     meta:
-      total: 5
+      total: 10
       sum:
         hours: 9.0
         minutes: 0
@@ -184,11 +204,27 @@ GetAll:
         "time": "9.00"
       },
       {
+        "employeeName": "Ashley Abel",
+        "time": "0.00"
+      },
+      {
+        "employeeName": "mahatma gandhi",
+        "time": "0.00"
+      },
+      {
+        "employeeName": "Adolf Hitler",
+        "time": "0.00"
+      },
+      {
         "employeeName": "Vladimir Lenin",
         "time": "0.00"
       },
       {
         "employeeName": "Benito Mussolini (Past employee)",
+        "time": "0.00"
+      },
+      {
+        "employeeName": "Renukshan Saputhanthri",
         "time": "0.00"
       },
       {
@@ -198,10 +234,14 @@ GetAll:
       {
         "employeeName": "Tony Stark",
         "time": "0.00"
+      },
+      {
+        "employeeName": "mother teresa",
+        "time": "0.00"
       }
     ]
     meta:
-      total: 5
+      total: 10
       sum:
         hours: 9.0
         minutes: 0
@@ -351,16 +391,20 @@ GetAll:
       {
         "employeeName": "Kayla Abbey",
         "time": "9.00"
+      },
+      {
+        "employeeName": "Adolf Hitler",
+        "time": "0.00"
       }
     ]
     meta:
-      total: 1
+      total: 2
       sum:
         hours: 9.0
         minutes: 0
         label: "9.00"
 
-  'Get all attendance record breakdownbreakdown for an employee without filter':
+  'Get all attendance record breakdown for an employee without filter':
     userId: 1
     services:
       core.config_service: \OrangeHRM\Core\Service\ConfigService


### PR DESCRIPTION
This PR Contains following fixes:
1. OHRM5X-1154 : Attendance details are not getting filtered properly when user select the same date in both from and to date pickers.
2. OHRM5X-1155: When generating report with sub unit and the date range, employees with no attendance records are not getting displayed.
3. OHRM5X-1156: When generating report with sub unit and the date range, employees with no attendance records are not getting displayed.