### PR TITLE
OHRM5X-1565: Fix recruitment - candidate, vacancy related issues

### DIFF
--- a/installer/Migration/V5_1_0/Migration.php
+++ b/installer/Migration/V5_1_0/Migration.php
@@ -200,6 +200,8 @@ class Migration extends AbstractMigration
 
         $this->updateRecruitmentMenuItems();
         $this->updatePerformanceMenuItems();
+
+        $this->modifyEmployeeTrackerScreenRolePermission($performanceModuleId);
     }
 
     /**
@@ -448,6 +450,34 @@ class Migration extends AbstractMigration
             ['onDelete' => 'SET NULL', 'onUpdate' => 'CASCADE']
         );
         $this->getSchemaHelper()->addForeignKey('ohrm_performance_tracker_log', $foreignKeyConstraint);
+    }
+
+    /**
+     * @param int $performanceModuleId
+     */
+    private function modifyEmployeeTrackerScreenRolePermission(int $performanceModuleId): void
+    {
+        $employeeTrackerScreenId = $this->getDataGroupHelper()
+            ->getScreenIdByModuleAndUrl(
+                $performanceModuleId,
+                'viewEmployeePerformanceTrackerList',
+            );
+
+        $this->createQueryBuilder()
+            ->update('ohrm_user_role_screen', 'userRoleScreen')
+            ->set('userRoleScreen.user_role_id', ':userRoleId')
+            ->setParameter(
+                'userRoleId',
+                $this->getDataGroupHelper()->getUserRoleIdByName('Reviewer')
+            )
+            ->andWhere('userRoleScreen.screen_id = :screenId')
+            ->andWhere('userRoleScreen.user_role_id = :oldUserRoleId')
+            ->setParameter('screenId', $employeeTrackerScreenId)
+            ->setParameter(
+                'oldUserRoleId',
+                $this->getDataGroupHelper()->getUserRoleIdByName('ESS')
+            )
+            ->executeQuery();
     }
 
     /**

--- a/src/client/src/orangehrmRecruitmentPlugin/pages/ViewJobVacancy.vue
+++ b/src/client/src/orangehrmRecruitmentPlugin/pages/ViewJobVacancy.vue
@@ -112,6 +112,7 @@ import {navigate} from '@ohrm/core/util/helper/navigation';
 import {APIService} from '@/core/util/services/api.service';
 import useSort from '@ohrm/core/util/composable/useSort';
 import usei18n from '@/core/util/composable/usei18n';
+import useEmployeeNameTranslate from '@/core/util/composable/useEmployeeNameTranslate';
 import JobtitleDropdown from '@/orangehrmPimPlugin/components/JobtitleDropdown';
 import DeleteConfirmationDialog from '@ohrm/components/dialogs/DeleteConfirmationDialog';
 import VacancyDropdown from '@/orangehrmRecruitmentPlugin/components/VacancyDropdown.vue';
@@ -140,6 +141,7 @@ export default {
 
   setup() {
     const {$t} = usei18n();
+    const {$tEmpName} = useEmployeeNameTranslate();
     const filters = ref({...defaultFilters});
     const {sortDefinition, sortField, sortOrder, onSort} = useSort({
       sortDefinition: defaultSortOrder,
@@ -165,11 +167,7 @@ export default {
             ? item.jobTitle.title + $t('general.deleted')
             : item.jobTitle?.title,
 
-          hiringManager: `${item.hiringManager?.firstName} ${
-            item.hiringManager?.lastName
-          } ${
-            item.hiringManager.terminationId ? $t('general.past_employee') : ''
-          }`,
+          hiringManager: $tEmpName(item.hiringManager),
           status:
             item.status == 1 ? $t('general.active') : $t('general.closed'),
         };

--- a/src/plugins/orangehrmPerformancePlugin/test/fixtures/SupervisorEvaluationAPITest.yaml
+++ b/src/plugins/orangehrmPerformancePlugin/test/fixtures/SupervisorEvaluationAPITest.yaml
@@ -242,3 +242,11 @@ ReportTo:
   4: { erep_sup_emp_number: 4, erep_sub_emp_number: 5, erep_reporting_mode: 2}
   5: { erep_sup_emp_number: 2, erep_sub_emp_number: 16, erep_reporting_mode: 2}
   6: { erep_sup_emp_number: 3, erep_sub_emp_number: 6, erep_reporting_mode: 2}
+
+DataGroup:
+  - {"id": 205,"name": "apiv2_performance_review_supervisor_evaluation","description": "API-v2 Performance - Performance Review Supervisor Evaluation","can_read": 1,"can_create": 0,"can_update": 1,"can_delete": 0}
+
+DataGroupPermission:
+  - {"id": 558,"user_role_id": 1,"data_group_id": 205,"can_read": 1,"can_create": 0,"can_update": 1,"can_delete": 0,"self": 0}
+  - {"id": 559,"user_role_id": 3,"data_group_id": 205,"can_read": 1,"can_create": 0,"can_update": 1,"can_delete": 0,"self": 0}
+  - {"id": 560,"user_role_id": 2,"data_group_id": 205,"can_read": 1,"can_create": 0,"can_update": 0,"can_delete": 0,"self": 0}

--- a/src/plugins/orangehrmRecruitmentPlugin/Controller/SaveCandidateController.php
+++ b/src/plugins/orangehrmRecruitmentPlugin/Controller/SaveCandidateController.php
@@ -20,14 +20,19 @@
 namespace OrangeHRM\Recruitment\Controller;
 
 use OrangeHRM\Core\Controller\AbstractVueController;
+use OrangeHRM\Core\Controller\Common\NoRecordsFoundController;
+use OrangeHRM\Core\Controller\Exception\RequestForwardableException;
 use OrangeHRM\Core\Service\ConfigService;
 use OrangeHRM\Core\Vue\Component;
 use OrangeHRM\Core\Vue\Prop;
 use OrangeHRM\Framework\Http\Request;
 use OrangeHRM\Recruitment\Service\RecruitmentAttachmentService;
+use OrangeHRM\Recruitment\Traits\Service\CandidateServiceTrait;
 
 class SaveCandidateController extends AbstractVueController
 {
+    use CandidateServiceTrait;
+
     protected ?ConfigService $configService = null;
 
     public function getConfigService(): ConfigService
@@ -44,8 +49,14 @@ class SaveCandidateController extends AbstractVueController
     public function preRender(Request $request): void
     {
         if ($request->attributes->has('id')) {
+            $id = $request->attributes->getInt('id');
+
+            if (is_null($this->getCandidateService()->getCandidateDao()->getCandidateById($id))) {
+                throw new RequestForwardableException(NoRecordsFoundController::class . '::handle');
+            }
+
             $component = new Component('view-candidate-profile');
-            $component->addProp(new Prop('candidate-id', Prop::TYPE_NUMBER, $request->attributes->getInt('id')));
+            $component->addProp(new Prop('candidate-id', Prop::TYPE_NUMBER, $id));
         } else {
             $component = new Component('save-candidate');
         }

--- a/src/plugins/orangehrmRecruitmentPlugin/Controller/WorkflowActionHistoryController.php
+++ b/src/plugins/orangehrmRecruitmentPlugin/Controller/WorkflowActionHistoryController.php
@@ -20,20 +20,34 @@
 namespace OrangeHRM\Recruitment\Controller;
 
 use OrangeHRM\Core\Controller\AbstractVueController;
+use OrangeHRM\Core\Controller\Common\NoRecordsFoundController;
+use OrangeHRM\Core\Controller\Exception\RequestForwardableException;
 use OrangeHRM\Core\Vue\Component;
 use OrangeHRM\Core\Vue\Prop;
 use OrangeHRM\Framework\Http\Request;
+use OrangeHRM\Recruitment\Traits\Service\CandidateServiceTrait;
 
 class WorkflowActionHistoryController extends AbstractVueController
 {
+    use CandidateServiceTrait;
+
     /**
      * @inheritDoc
      */
     public function preRender(Request $request): void
     {
         $component = new Component('view-action-history');
-        $component->addProp(new Prop('candidate-id', Prop::TYPE_NUMBER, $request->attributes->getInt('candidateId')));
-        $component->addProp(new Prop('history-id', Prop::TYPE_NUMBER, $request->attributes->getInt('historyId')));
+        $candidateId = $request->attributes->getInt('candidateId');
+        $historyId = $request->attributes->getInt('historyId');
+
+        if (is_null($this->getCandidateService()->getCandidateDao()->getCandidateById($candidateId)) ||
+            is_null($this->getCandidateService()->getCandidateDao()->getCandidateHistoryRecordByCandidateIdAndHistoryId($candidateId, $historyId))
+        ) {
+            throw new RequestForwardableException(NoRecordsFoundController::class . '::handle');
+        }
+
+        $component->addProp(new Prop('candidate-id', Prop::TYPE_NUMBER, $candidateId));
+        $component->addProp(new Prop('history-id', Prop::TYPE_NUMBER, $historyId));
         $this->setComponent($component);
     }
 }


### PR DESCRIPTION
PR contains:
- OHRM5X-1565: [Purge Candidates] When user access a purged candidates from the url an error toast message is displaying
- OHRM5X-1583: [Recruitment - Candidates] "Past Employee" tag is displayed along with the purged employee tag in the candidate list view.
    - Only fixed on vacancy list page. Other mentioned screens have been fixed in #1367 and #1370
- OHRM5X-1596: [Performance- Employee Trackers] Employees who are not assigned as reviewers can view the employee trackers screen.