### PR TITLE
OHRM5X-1596: Fix performance - tracker related issue

### DIFF
--- a/src/plugins/orangehrmPerformancePlugin/Dao/PerformanceTrackerDao.php
+++ b/src/plugins/orangehrmPerformancePlugin/Dao/PerformanceTrackerDao.php
@@ -333,6 +333,10 @@ class PerformanceTrackerDao extends BaseDao
         $qb = $this->createQueryBuilder(PerformanceTrackerReviewer::class, 'trackerReviewer');
         $qb->andWhere($qb->expr()->eq('trackerReviewer.reviewer', ':empNumber'))
             ->setParameter('empNumber', $empNumber);
+
+        $qb->leftJoin('trackerReviewer.performanceTracker', 'performanceTracker');
+        $qb->andWhere($qb->expr()->eq('performanceTracker.status', ':status'))
+            ->setParameter('status', PerformanceTracker::STATUS_TRACKER_NOT_DELETED);
         return $this->getPaginator($qb)->count() > 0;
     }
 


### PR DESCRIPTION
- OHRM5X-1596: Fixed reopen issue
    - Note that menu items are cached so that if an ESS user has the tracker they are assigned to deleted while they are logged in, the menu item will remain but the page will not be accessible and will show credential required.
    - Once they log in and log out the menu item will be gone