### PR TITLE
OHRM5X-1695: Add upgrader - encryption note to copy the key

### DIFF
--- a/installer/client/src/pages/DatabaseInfoScreen.vue
+++ b/installer/client/src/pages/DatabaseInfoScreen.vue
@@ -41,6 +41,14 @@
       </oxd-text>
     </Notice>
     <br />
+    <Notice title="encryption" class="orangehrm-installer-page-notice">
+      <oxd-text tag="p" class="orangehrm-installer-page-content">
+        If you have enabled data encryption in your current version, you need to
+        copy the file 'lib/confs/cryptokeys/key.ohrm' from your current
+        installation to corresponding location in the new version.
+      </oxd-text>
+    </Notice>
+    <br />
     <oxd-grid :cols="3" class="orangehrm-full-width-grid">
       <oxd-grid-item>
         <oxd-input-field


### PR DESCRIPTION
PR contains:
- [OHRM5X-1695] [Encryption- Upgrade]User is not informed about having to copy crypto key from 4x to 5x when upgrading.

Added the note to the Database Info Screen

![image](https://user-images.githubusercontent.com/97493184/190923407-e841c115-8a9f-454a-ac87-3b26cb689bc0.png)
