### PR TITLE
OHRM5X-2451: Fix redirect for module controller

### DIFF
--- a/src/plugins/orangehrmAdminPlugin/Service/LocalizationService.php
+++ b/src/plugins/orangehrmAdminPlugin/Service/LocalizationService.php
@@ -261,7 +261,7 @@ class LocalizationService
                     $target = $xml->createElement('target');
 
                     $source->appendChild(new \DOMText(htmlspecialchars($translation['source'])));
-                    $target->appendChild(new \DOMText(htmlspecialchars($translation['target'])));
+                    $target->appendChild(new \DOMText(htmlspecialchars($translation['target'] ?? '')));
 
                     $segment->appendChild($source);
                     $segment->appendChild($target);

--- a/src/plugins/orangehrmAdminPlugin/Service/UserService.php
+++ b/src/plugins/orangehrmAdminPlugin/Service/UserService.php
@@ -80,7 +80,11 @@ class UserService
             return $user;
         }
         if (!is_null($user->getDecorator()->getNonHashedPassword())) {
-            $user->setUserPassword($this->hashPassword($user->getDecorator()->getNonHashedPassword()));
+            $user->setUserPassword(
+                $user->getDecorator()->getNonHashedPassword() !==  "" ?
+                    $this->hashPassword($user->getDecorator()->getNonHashedPassword()) :
+                    null
+            );
             $user->getDecorator()->setNonHashedPassword(null);
         }
 

--- a/src/plugins/orangehrmAuthenticationPlugin/Subscriber/AuthenticationSubscriber.php
+++ b/src/plugins/orangehrmAuthenticationPlugin/Subscriber/AuthenticationSubscriber.php
@@ -22,6 +22,7 @@ use Exception;
 use OrangeHRM\Authentication\Auth\User as AuthUser;
 use OrangeHRM\Authentication\Exception\SessionExpiredException;
 use OrangeHRM\Authentication\Exception\UnauthorizedException;
+use OrangeHRM\Core\Controller\AbstractModuleController;
 use OrangeHRM\Core\Controller\AbstractViewController;
 use OrangeHRM\Core\Controller\PublicControllerInterface;
 use OrangeHRM\Core\Controller\Rest\V2\AbstractRestController;
@@ -80,7 +81,10 @@ class AuthenticationSubscriber extends AbstractEventSubscriber
             return;
         }
 
-        if ($this->getControllerInstance($event) instanceof AbstractViewController) {
+        if (
+            $this->getControllerInstance($event) instanceof AbstractViewController ||
+            $this->getControllerInstance($event) instanceof AbstractModuleController
+        ) {
             /** @var UrlHelper $urlHelper */
             $urlHelper = $this->getContainer()->get(Services::URL_HELPER);
             $requestUri = $event->getRequest()->getRequestUri();


### PR DESCRIPTION
PR contains fix for reopen:
- OHRM5X-2451: [General] User always redirect to "Dashboard" when he login to the system after a time out
- OHRM5X-2421: [BE]Change user password as not required after add oidc provider
- OHRM5X-2467: [Environment][Language pack] language export feature not working for php82 and above version