### PR TITLE
OHRM5X-2547: Bump MySQL, MariaDB supported versions

### DIFF
--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -24,6 +24,7 @@ jobs:
           - { image: "mysql:8.0", admin: "mysqladmin" }
           - { image: "mysql:8.1", admin: "mysqladmin" }
           - { image: "mysql:8.2", admin: "mysqladmin" }
+          - { image: "mysql:8.3", admin: "mysqladmin" }
           - { image: "mariadb:5.5", admin: "mysqladmin" }
           - { image: "mariadb:10.0", admin: "mysqladmin" }
           - { image: "mariadb:10.1", admin: "mysqladmin" }
@@ -40,6 +41,7 @@ jobs:
           - { image: "mariadb:11.0", admin: "mariadb-admin" }
           - { image: "mariadb:11.1", admin: "mariadb-admin" }
           - { image: "mariadb:11.2", admin: "mariadb-admin" }
+          - { image: "mariadb:11.3", admin: "mariadb-admin" }
 
     services:
       mysql:

--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -8,8 +8,8 @@ Changed Features for OrangeHRM ver 5.6.1
         - Update Docker PHP image
     - Supported Environments
         - PHP - 7.4 to 8.3
-        - MariaDB - 5.5 to 11.2
-        - MySQL - 5.5 to 8.2
+        - MariaDB - 5.5 to 11.3
+        - MySQL - 5.5 to 8.3
 
      Bug Fixes
      -----------

--- a/installer/client/yarn.lock
+++ b/installer/client/yarn.lock
@@ -9387,8 +9387,8 @@ __metadata:
   linkType: hard
 
 "webpack-dev-middleware@npm:^5.3.1":
-  version: 5.3.3
-  resolution: "webpack-dev-middleware@npm:5.3.3"
+  version: 5.3.4
+  resolution: "webpack-dev-middleware@npm:5.3.4"
   dependencies:
     colorette: "npm:^2.0.10"
     memfs: "npm:^3.4.3"
@@ -9397,7 +9397,7 @@ __metadata:
     schema-utils: "npm:^4.0.0"
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
-  checksum: 10/31a2f7a11e58a76bdcde1eb8da310b6643844d9b442f9916f48be5b46c103f23490c393c32a9af501ce68226fbb018b811f5a956635ed60a03f9481a4bcd6c76
+  checksum: 10/3004374130f31c2910da39b80e24296009653bb11caa0b8449d962b67e003d7e73d01fbcfda9be1f1f04179f66a9c39f4caf7963df54303b430e39ba5a94f7c2
   languageName: node
   linkType: hard
 

--- a/installer/config/system_requirements.php
+++ b/installer/config/system_requirements.php
@@ -25,13 +25,13 @@ return [
 
     'mysqlversion' => [
         'min' => '5.5',
-        'max' => '8.2',
+        'max' => '8.3',
         'excludeRange' => [],
     ],
 
     'mariadbversion' => [
         'min' => '5.5',
-        'max' => '11.2',
+        'max' => '11.3',
         'excludeRange' => [],
     ],
 

--- a/src/client/src/orangehrmClaimPlugin/pages/employeeClaims/EmployeeClaims.vue
+++ b/src/client/src/orangehrmClaimPlugin/pages/employeeClaims/EmployeeClaims.vue
@@ -157,8 +157,8 @@ const defaultFilters = {
 
 const defaultSortOrder = {
   'claimRequest.referenceId': 'DESC',
-  'claimRequest.employee.firstName': 'ASC',
-  'claimRequest.claimEvent.name': 'ASC',
+  'employee.firstName': 'ASC',
+  'claimEvent.name': 'ASC',
   'claimRequest.status': 'ASC',
   'claimRequest.submittedDate': 'ASC',
 };
@@ -290,7 +290,7 @@ export default {
           name: 'employee',
           title: this.$t('general.employee_name'),
           slot: 'title',
-          sortField: 'claimRequest.employee.firstName',
+          sortField: 'employee.firstName',
           style: {flex: 4},
         },
         {
@@ -298,7 +298,7 @@ export default {
           title: this.$t('claim.event_name'),
           slot: 'title',
           cellType: 'oxd-table-cell-truncate',
-          sortField: 'claimRequest.claimEvent.name',
+          sortField: 'claimEvent.name',
           style: {flex: 3},
         },
         {

--- a/src/client/yarn.lock
+++ b/src/client/yarn.lock
@@ -12203,8 +12203,8 @@ __metadata:
   linkType: hard
 
 "webpack-dev-middleware@npm:^5.3.1":
-  version: 5.3.3
-  resolution: "webpack-dev-middleware@npm:5.3.3"
+  version: 5.3.4
+  resolution: "webpack-dev-middleware@npm:5.3.4"
   dependencies:
     colorette: "npm:^2.0.10"
     memfs: "npm:^3.4.3"
@@ -12213,7 +12213,7 @@ __metadata:
     schema-utils: "npm:^4.0.0"
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
-  checksum: 10/31a2f7a11e58a76bdcde1eb8da310b6643844d9b442f9916f48be5b46c103f23490c393c32a9af501ce68226fbb018b811f5a956635ed60a03f9481a4bcd6c76
+  checksum: 10/3004374130f31c2910da39b80e24296009653bb11caa0b8449d962b67e003d7e73d01fbcfda9be1f1f04179f66a9c39f4caf7963df54303b430e39ba5a94f7c2
   languageName: node
   linkType: hard
 

--- a/src/plugins/orangehrmPimPlugin/Dao/EmployeeDao.php
+++ b/src/plugins/orangehrmPimPlugin/Dao/EmployeeDao.php
@@ -38,7 +38,7 @@ class EmployeeDao extends BaseDao
     public function getEmployeeList(EmployeeSearchFilterParams $employeeSearchParamHolder): array
     {
         $qb = $this->getEmployeeListQueryBuilderWrapper($employeeSearchParamHolder)->getQueryBuilder();
-        return $qb->getQuery()->execute();
+        return array_column($qb->getQuery()->execute(), 0);
     }
 
     /**
@@ -73,6 +73,7 @@ class EmployeeDao extends BaseDao
         EmployeeSearchFilterParams $employeeSearchParamHolder
     ): QueryBuilderWrapper {
         $q = $this->createQueryBuilder(Employee::class, 'employee');
+        $q->addSelect('employee.empNumber');
         $q->distinct();
         $q->leftJoin('employee.jobTitle', 'jobTitle');
         $q->leftJoin('employee.subDivision', 'subunit');
@@ -86,6 +87,9 @@ class EmployeeDao extends BaseDao
         }
 
         $this->setSortingAndPaginationParams($q, $employeeSearchParamHolder);
+        if ($employeeSearchParamHolder->getSortField() !== null && $employeeSearchParamHolder->getSortField() !== "") {
+            $q->addSelect($employeeSearchParamHolder->getSortField());
+        }
 
         if (is_null($employeeSearchParamHolder->getIncludeEmployees()) ||
             $employeeSearchParamHolder->getIncludeEmployees() ===


### PR DESCRIPTION
PR contains:
- OHRM5X-2547: Bump MySQL and MariaDB versions
- OHRM5X-2458: [Broken][PIM][Fresh instance] Shows an "Unexpected Error" message when clicking on sorting option in "Job Titile" column.
- OHRM5X-2459: [Claim][Table] Shows invalid parameter message when click on sorting option in "employee name" column on "employee claim" page

Additionally updated webpack-dev-middleware due to new advisory: https://github.com/advisories/GHSA-wr3j-pwj9-hqq6