### PR TITLE
OHRM5X-2656: Block .yaml in root .htaccess and purge CLI install config

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,11 +14,7 @@ deny from all
 order allow,deny
 deny from all
 </Files>
-<Files *.yml>
-order allow,deny
-deny from all
-</Files>
-<FilesMatch "(\.(bak|config|dist|inc|swp|xml|sql|sh|xsl|conf|ini|json)|~)$">
+<FilesMatch "(\.(bak|config|dist|inc|swp|xml|sql|sh|xsl|conf|ini|json|yml|yaml)|~)$">
     ## Apache 2.2
     order allow,deny
     deny from all

--- a/installer/cli_install.php
+++ b/installer/cli_install.php
@@ -156,4 +156,15 @@ $request = new Request();
 $request->setMethod(Request::METHOD_POST);
 (new InstallerDataRegistrationAPI())->handle($request);
 
+// Remove the CLI install config now that the install succeeded. It holds the
+// plaintext DB credentials supplied by the operator and must not persist in the
+// web-accessible installer/ directory post-install (OPOS-2). This is the
+// portable mitigation — the root .htaccess deny rule only protects Apache.
+$cliConfigPath = realpath(__DIR__ . '/cli_install_config.yaml');
+if ($cliConfigPath !== false && is_file($cliConfigPath) && @unlink($cliConfigPath)) {
+    echo "Removed cli_install_config.yaml (it contained plaintext DB credentials)\n";
+} else {
+    echo "WARNING: Could not remove '$cliConfigPath'. Delete it manually — it contains plaintext DB credentials.\n";
+}
+
 echo "Done\n";

--- a/installer/cli_install.php
+++ b/installer/cli_install.php
@@ -156,10 +156,6 @@ $request = new Request();
 $request->setMethod(Request::METHOD_POST);
 (new InstallerDataRegistrationAPI())->handle($request);
 
-// Remove the CLI install config now that the install succeeded. It holds the
-// plaintext DB credentials supplied by the operator and must not persist in the
-// web-accessible installer/ directory post-install (OPOS-2). This is the
-// portable mitigation — the root .htaccess deny rule only protects Apache.
 $cliConfigPath = realpath(__DIR__ . '/cli_install_config.yaml');
 if ($cliConfigPath !== false && is_file($cliConfigPath) && @unlink($cliConfigPath)) {
     echo "Removed cli_install_config.yaml (it contained plaintext DB credentials)\n";

--- a/installer/cli_install.php
+++ b/installer/cli_install.php
@@ -19,6 +19,7 @@
 
 use OrangeHRM\Authentication\Dto\UserCredential;
 use OrangeHRM\Config\Config;
+use OrangeHRM\Framework\Filesystem\Filesystem;
 use OrangeHRM\Framework\Http\Session\MemorySessionStorage;
 use OrangeHRM\Framework\Http\Session\Session;
 use OrangeHRM\Framework\ServiceContainer;
@@ -66,7 +67,8 @@ $session = new Session($sessionStorage);
 $session->start();
 ServiceContainer::getContainer()->set(Services::SESSION, $session);
 
-$cliConfig = Yaml::parseFile(realpath(__DIR__ . '/cli_install_config.yaml'));
+$cliConfigPath = realpath(__DIR__ . '/cli_install_config.yaml');
+$cliConfig = Yaml::parseFile($cliConfigPath);
 
 if ($cliConfig['license']['agree'] != 'y') {
     $licenseFilePath = realpath(__DIR__ . '/../LICENSE');
@@ -156,11 +158,14 @@ $request = new Request();
 $request->setMethod(Request::METHOD_POST);
 (new InstallerDataRegistrationAPI())->handle($request);
 
-$cliConfigPath = realpath(__DIR__ . '/cli_install_config.yaml');
-if ($cliConfigPath !== false && is_file($cliConfigPath) && @unlink($cliConfigPath)) {
-    echo "Removed cli_install_config.yaml (it contained plaintext DB credentials)\n";
-} else {
-    echo "WARNING: Could not remove '$cliConfigPath'. Delete it manually — it contains plaintext DB credentials.\n";
+$filesystem = new Filesystem();
+if ($cliConfigPath !== false && $filesystem->exists($cliConfigPath)) {
+    try {
+        $filesystem->remove($cliConfigPath);
+        echo "Removed cli_install_config.yaml (it contained plaintext DB credentials)\n";
+    } catch (Throwable $e) {
+        echo "WARNING: Could not remove '$cliConfigPath'. Delete it manually — it contains plaintext DB credentials.\n";
+    }
 }
 
 echo "Done\n";

--- a/src/plugins/orangehrmCorePlugin/test/Security/HtaccessSecurityTest.php
+++ b/src/plugins/orangehrmCorePlugin/test/Security/HtaccessSecurityTest.php
@@ -23,12 +23,6 @@ use OrangeHRM\Config\Config;
 use OrangeHRM\Tests\Util\TestCase;
 
 /**
- * Guards the document-root Apache hardening rules.
- *
- * Regression cover for OPOS-2: the root `.htaccess` denied `*.yml` but not
- * `*.yaml`, leaving `installer/cli_install_config.yaml` (which holds plaintext
- * DB credentials post-install) fetchable by direct URL on Apache deployments.
- *
  * @group Core
  * @group Security
  */
@@ -43,14 +37,11 @@ class HtaccessSecurityTest extends TestCase
         $this->htaccessContents = file_get_contents($htaccessPath);
     }
 
-    /**
-     * Sensitive YAML credential files must be denied by the root .htaccess.
-     */
     public function testYamlFilesAreDenied(): void
     {
         $this->assertTrue(
             $this->isDeniedByHtaccess('cli_install_config.yaml'),
-            'installer/cli_install_config.yaml must be blocked by the root .htaccess (OPOS-2)'
+            'installer/cli_install_config.yaml must be blocked by the root .htaccess'
         );
         $this->assertTrue(
             $this->isDeniedByHtaccess('anything.yaml'),
@@ -58,9 +49,6 @@ class HtaccessSecurityTest extends TestCase
         );
     }
 
-    /**
-     * Existing `.yml` coverage must not regress.
-     */
     public function testYmlFilesRemainDenied(): void
     {
         $this->assertTrue(
@@ -69,10 +57,6 @@ class HtaccessSecurityTest extends TestCase
         );
     }
 
-    /**
-     * Sanity check: regular application entry points must stay reachable, so
-     * the assertions above are meaningful and not "everything is denied".
-     */
     public function testRegularFilesAreNotDenied(): void
     {
         $this->assertFalse(
@@ -81,14 +65,8 @@ class HtaccessSecurityTest extends TestCase
         );
     }
 
-    /**
-     * Mirrors how Apache evaluates the deny rules in this .htaccess: every
-     * `<Files glob>` block is matched with fnmatch and every `<FilesMatch regex>`
-     * block with PCRE. Only blocks that actually deny access are considered.
-     */
     private function isDeniedByHtaccess(string $fileName): bool
     {
-        // <Files PATTERN> ... </Files> (glob match)
         if (preg_match_all('#<Files\s+([^>~]+?)\s*>(.*?)</Files>#is', $this->htaccessContents, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 if ($this->blockDenies($match[2]) && fnmatch(trim($match[1]), $fileName)) {
@@ -97,7 +75,6 @@ class HtaccessSecurityTest extends TestCase
             }
         }
 
-        // <FilesMatch "REGEX"> ... </FilesMatch> (PCRE match)
         if (preg_match_all('#<FilesMatch\s+"(.*?)"\s*>(.*?)</FilesMatch>#is', $this->htaccessContents, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 if ($this->blockDenies($match[2]) && preg_match('#' . $match[1] . '#', $fileName)) {
@@ -109,10 +86,6 @@ class HtaccessSecurityTest extends TestCase
         return false;
     }
 
-    /**
-     * A directive block denies access if it carries an (uncommented) deny rule
-     * in either the Apache 2.2 or 2.4 syntax.
-     */
     private function blockDenies(string $blockBody): bool
     {
         foreach (explode("\n", $blockBody) as $line) {

--- a/src/plugins/orangehrmCorePlugin/test/Security/HtaccessSecurityTest.php
+++ b/src/plugins/orangehrmCorePlugin/test/Security/HtaccessSecurityTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OrangeHRM.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OrangeHRM\Tests\Core\Security;
+
+use OrangeHRM\Config\Config;
+use OrangeHRM\Tests\Util\TestCase;
+
+/**
+ * Guards the document-root Apache hardening rules.
+ *
+ * Regression cover for OPOS-2: the root `.htaccess` denied `*.yml` but not
+ * `*.yaml`, leaving `installer/cli_install_config.yaml` (which holds plaintext
+ * DB credentials post-install) fetchable by direct URL on Apache deployments.
+ *
+ * @group Core
+ * @group Security
+ */
+class HtaccessSecurityTest extends TestCase
+{
+    private string $htaccessContents;
+
+    protected function setUp(): void
+    {
+        $htaccessPath = Config::get(Config::BASE_DIR) . '/.htaccess';
+        $this->assertFileExists($htaccessPath, 'Document-root .htaccess is missing');
+        $this->htaccessContents = file_get_contents($htaccessPath);
+    }
+
+    /**
+     * Sensitive YAML credential files must be denied by the root .htaccess.
+     */
+    public function testYamlFilesAreDenied(): void
+    {
+        $this->assertTrue(
+            $this->isDeniedByHtaccess('cli_install_config.yaml'),
+            'installer/cli_install_config.yaml must be blocked by the root .htaccess (OPOS-2)'
+        );
+        $this->assertTrue(
+            $this->isDeniedByHtaccess('anything.yaml'),
+            '.yaml files must be blocked by the root .htaccess'
+        );
+    }
+
+    /**
+     * Existing `.yml` coverage must not regress.
+     */
+    public function testYmlFilesRemainDenied(): void
+    {
+        $this->assertTrue(
+            $this->isDeniedByHtaccess('config.yml'),
+            '.yml files must remain blocked by the root .htaccess'
+        );
+    }
+
+    /**
+     * Sanity check: regular application entry points must stay reachable, so
+     * the assertions above are meaningful and not "everything is denied".
+     */
+    public function testRegularFilesAreNotDenied(): void
+    {
+        $this->assertFalse(
+            $this->isDeniedByHtaccess('index.php'),
+            'index.php must remain web-accessible'
+        );
+    }
+
+    /**
+     * Mirrors how Apache evaluates the deny rules in this .htaccess: every
+     * `<Files glob>` block is matched with fnmatch and every `<FilesMatch regex>`
+     * block with PCRE. Only blocks that actually deny access are considered.
+     */
+    private function isDeniedByHtaccess(string $fileName): bool
+    {
+        // <Files PATTERN> ... </Files> (glob match)
+        if (preg_match_all('#<Files\s+([^>~]+?)\s*>(.*?)</Files>#is', $this->htaccessContents, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                if ($this->blockDenies($match[2]) && fnmatch(trim($match[1]), $fileName)) {
+                    return true;
+                }
+            }
+        }
+
+        // <FilesMatch "REGEX"> ... </FilesMatch> (PCRE match)
+        if (preg_match_all('#<FilesMatch\s+"(.*?)"\s*>(.*?)</FilesMatch>#is', $this->htaccessContents, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                if ($this->blockDenies($match[2]) && preg_match('#' . $match[1] . '#', $fileName)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A directive block denies access if it carries an (uncommented) deny rule
+     * in either the Apache 2.2 or 2.4 syntax.
+     */
+    private function blockDenies(string $blockBody): bool
+    {
+        foreach (explode("\n", $blockBody) as $line) {
+            $line = trim($line);
+            if ($line === '' || (isset($line[0]) && $line[0] === '#')) {
+                continue;
+            }
+            if (stripos($line, 'deny from all') !== false || stripos($line, 'Require all denied') !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
The root .htaccess denied *.yml but not *.yaml, so on Apache deployments installer/cli_install_config.yaml (overwritten with real plaintext DB credentials at install time and retained post-install) was fetchable via direct URL.

Solution A: fold yml|yaml into the FilesMatch deny pattern and drop the now-redundant standalone <Files *.yml> block.

Solution B: cli_install.php now removes cli_install_config.yaml on successful completion — the portable mitigation, since .htaccess does not cover nginx/Caddy/IIS/built-in-server deployments.

Adds HtaccessSecurityTest regression cover (Core suite).