### PR TITLE
OHRM5X-2658 - OHRM5X-2659 - OHRM5X-2660 : Fix TOCTOU races and IDOR in claim, attendance and recruitment APIs

### DIFF
--- a/src/plugins/orangehrmAttendancePlugin/Api/EmployeeAttendanceRecordAPI.php
+++ b/src/plugins/orangehrmAttendancePlugin/Api/EmployeeAttendanceRecordAPI.php
@@ -44,6 +44,7 @@ use OrangeHRM\Core\Api\V2\Validator\Rule;
 use OrangeHRM\Core\Api\V2\Validator\Rules;
 use OrangeHRM\Core\Service\DateTimeHelperService;
 use OrangeHRM\Core\Traits\Auth\AuthUserTrait;
+use OrangeHRM\Core\Traits\ORM\EntityManagerHelperTrait;
 use OrangeHRM\Core\Traits\Service\DateTimeHelperTrait;
 use OrangeHRM\Core\Traits\Service\NumberHelperTrait;
 use OrangeHRM\Core\Traits\UserRoleManagerTrait;
@@ -54,6 +55,7 @@ use OrangeHRM\Entity\WorkflowStateMachine;
 class EmployeeAttendanceRecordAPI extends Endpoint implements CrudEndpoint
 {
     use AttendanceServiceTrait;
+    use EntityManagerHelperTrait;
     use AuthUserTrait;
     use DateTimeHelperTrait;
     use UserRoleManagerTrait;
@@ -293,6 +295,7 @@ class EmployeeAttendanceRecordAPI extends Endpoint implements CrudEndpoint
      */
     public function create(): EndpointResourceResult
     {
+        $this->beginTransaction();
         try {
             list($empNumber, $date, $time, $timezoneOffset, $timezoneName, $note) = $this->getCommonRequestParams();
             $allowedWorkflowItems = $this->getUserRoleManager()->getAllowedActions(
@@ -311,7 +314,7 @@ class EmployeeAttendanceRecordAPI extends Endpoint implements CrudEndpoint
             );
             $overlappingPunchInRecords = $this->getAttendanceService()
                 ->getAttendanceDao()
-                ->checkForPunchInOverLappingRecords($punchInUTCDateTime, $empNumber);
+                ->checkForPunchInOverLappingRecordsForUpdate($punchInUTCDateTime, $empNumber);
             if ($overlappingPunchInRecords) {
                 throw AttendanceServiceException::punchInOverlapFound();
             }
@@ -325,9 +328,14 @@ class EmployeeAttendanceRecordAPI extends Endpoint implements CrudEndpoint
                 $note
             );
             $attendanceRecord = $this->getAttendanceService()->getAttendanceDao()->savePunchRecord($attendanceRecord);
+            $this->commitTransaction();
             return new EndpointResourceResult(AttendanceRecordModel::class, $attendanceRecord);
         } catch (AttendanceServiceException $e) {
+            $this->rollBackTransaction();
             throw $this->getBadRequestException($e->getMessage());
+        } catch (Exception $e) {
+            $this->rollBackTransaction();
+            throw $e;
         }
     }
 

--- a/src/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
+++ b/src/plugins/orangehrmAttendancePlugin/Dao/AttendanceDao.php
@@ -20,6 +20,7 @@
 namespace OrangeHRM\Attendance\Dao;
 
 use DateTime;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use OrangeHRM\Attendance\Dto\AttendanceRecordSearchFilterParams;
@@ -101,6 +102,46 @@ class AttendanceDao extends BaseDao
         }
 
         return $this->getCommonQueryForPunchInOverlap($punchInTime, $employeeNumber);
+    }
+
+    /**
+     * Same as checkForPunchInOverLappingRecords() but reads the employee's latest attendance
+     * record under a pessimistic write lock so concurrent punch-ins for the same employee are
+     * serialised. Must be called inside an active transaction.
+     *
+     * @param DateTime $punchInTime
+     * @param int $employeeNumber
+     * @return bool false if no overlap found
+     * @throws AttendanceServiceException
+     */
+    public function checkForPunchInOverLappingRecordsForUpdate(DateTime $punchInTime, int $employeeNumber): bool
+    {
+        $attendanceRecord = $this->getLatestAttendanceRecordByEmployeeNumberForUpdate($employeeNumber);
+        if (is_null($attendanceRecord)) {
+            return false;
+        }
+        if ($attendanceRecord->getState() === AttendanceRecord::STATE_PUNCHED_IN) {
+            throw AttendanceServiceException::punchInAlreadyExist();
+        }
+
+        return $this->getCommonQueryForPunchInOverlap($punchInTime, $employeeNumber);
+    }
+
+    /**
+     * @param int $employeeNumber
+     * @return AttendanceRecord|null
+     */
+    private function getLatestAttendanceRecordByEmployeeNumberForUpdate(int $employeeNumber): ?AttendanceRecord
+    {
+        $q = $this->createQueryBuilder(AttendanceRecord::class, 'attendanceRecord');
+        $q->andWhere('attendanceRecord.employee = :empNumber');
+        $q->setParameter('empNumber', $employeeNumber);
+        $q->orderBy('attendanceRecord.id', ListSorter::DESCENDING);
+        $q->setMaxResults(1);
+
+        $query = $q->getQuery();
+        $query->setLockMode(LockMode::PESSIMISTIC_WRITE);
+        return $query->getOneOrNullResult();
     }
 
     /**

--- a/src/plugins/orangehrmAttendancePlugin/test/Dao/AttendanceDaoTest.php
+++ b/src/plugins/orangehrmAttendancePlugin/test/Dao/AttendanceDaoTest.php
@@ -21,6 +21,8 @@ namespace OrangeHRM\Tests\Attendance\Dao;
 
 use DateTime;
 use DateTimeZone;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\RetryableException;
 use Doctrine\ORM\TransactionRequiredException;
 use Exception;
 use OrangeHRM\Admin\Service\CompanyStructureService;
@@ -157,6 +159,64 @@ class AttendanceDaoTest extends KernelTestCase
             );
         } finally {
             $connection->rollBack();
+        }
+    }
+
+    /**
+     * Concurrency proof for the punch-in overlap lock: two simultaneous punch-ins for the
+     * same employee must be serialised so they cannot both pass the overlap check and create
+     * duplicate open records. Connection A (the EntityManager connection) holds the
+     * pessimistic write lock taken by checkForPunchInOverLappingRecordsForUpdate(), which
+     * locks the employee's latest attendance record. A second, independent connection B then
+     * runs the same latest-record FOR UPDATE query with a 1-second innodb_lock_wait_timeout
+     * and must block on A's lock, failing with a retryable lock-contention error — the
+     * observable signature of a genuine row lock.
+     *
+     * This also runs the FOR UPDATE read against the real database, so any version-specific
+     * incompatibility surfaces on every CI DB-compatibility matrix entry (MySQL / MariaDB).
+     */
+    public function testCheckForPunchInOverLappingRecordsForUpdateLocksLatestRecordAgainstConcurrentPunchIn(): void
+    {
+        $utcTimeZone = new DateTimeZone(DateTimeHelperService::TIMEZONE_UTC);
+        $emConnection = Doctrine::getEntityManager()->getConnection();
+        $secondConnection = DriverManager::getConnection($emConnection->getParams());
+        // Fail fast instead of waiting the server default lock-wait timeout (often 50s).
+        $secondConnection->executeStatement('SET SESSION innodb_lock_wait_timeout = 1');
+
+        $emConnection->beginTransaction();
+        try {
+            // Employee 5 last punched out: this call locks their latest record (no overlap).
+            $this->assertFalse(
+                $this->attendanceDao->checkForPunchInOverLappingRecordsForUpdate(
+                    new DateTime("2011-04-22 09:25:00", $utcTimeZone),
+                    5
+                )
+            );
+
+            // A concurrent punch-in for the same employee locks the same latest record.
+            $secondConnection->beginTransaction();
+            $lockContention = null;
+            try {
+                $secondConnection->executeQuery(
+                    'SELECT id FROM ohrm_attendance_record WHERE employee_id = ? ORDER BY id DESC LIMIT 1 FOR UPDATE',
+                    [5]
+                );
+            } catch (RetryableException $e) {
+                $lockContention = $e;
+            }
+
+            $this->assertInstanceOf(
+                RetryableException::class,
+                $lockContention,
+                'A concurrent punch-in must block on the latest-record write lock held by the '
+                . 'first transaction, proving punch-ins for the same employee are serialised.'
+            );
+        } finally {
+            if ($secondConnection->isTransactionActive()) {
+                $secondConnection->rollBack();
+            }
+            $secondConnection->close();
+            $emConnection->rollBack();
         }
     }
 

--- a/src/plugins/orangehrmAttendancePlugin/test/Dao/AttendanceDaoTest.php
+++ b/src/plugins/orangehrmAttendancePlugin/test/Dao/AttendanceDaoTest.php
@@ -21,6 +21,7 @@ namespace OrangeHRM\Tests\Attendance\Dao;
 
 use DateTime;
 use DateTimeZone;
+use Doctrine\ORM\TransactionRequiredException;
 use Exception;
 use OrangeHRM\Admin\Service\CompanyStructureService;
 use OrangeHRM\Attendance\Dao\AttendanceDao;
@@ -30,6 +31,7 @@ use OrangeHRM\Attendance\Exception\AttendanceServiceException;
 use OrangeHRM\Config\Config;
 use OrangeHRM\Core\Service\DateTimeHelperService;
 use OrangeHRM\Framework\Services;
+use OrangeHRM\ORM\Doctrine;
 use OrangeHRM\Tests\Util\KernelTestCase;
 use OrangeHRM\Tests\Util\TestDataService;
 use OrangeHRM\Time\Dto\AttendanceReportSearchFilterParams;
@@ -110,6 +112,52 @@ class AttendanceDaoTest extends KernelTestCase
             5
         );
         $this->assertTrue($overlapStatus);
+    }
+
+    /**
+     * The locked overlap check must take a pessimistic write lock: Doctrine raises
+     * TransactionRequiredException when a pessimistic-write query runs without an active
+     * transaction, which confirms the overlap read is locked rather than a plain SELECT.
+     */
+    public function testCheckForPunchInOverLappingRecordsForUpdateRequiresTransactionForLock(): void
+    {
+        $utcTimeZone = new DateTimeZone(DateTimeHelperService::TIMEZONE_UTC);
+        $this->expectException(TransactionRequiredException::class);
+        $this->attendanceDao->checkForPunchInOverLappingRecordsForUpdate(
+            new DateTime("2011-04-22 09:25:00", $utcTimeZone),
+            5
+        );
+    }
+
+    public function testCheckForPunchInOverLappingRecordsForUpdateWithinTransaction(): void
+    {
+        $utcTimeZone = new DateTimeZone(DateTimeHelperService::TIMEZONE_UTC);
+        $connection = Doctrine::getEntityManager()->getConnection();
+        $connection->beginTransaction();
+        try {
+            // Employee 5 last punched out; a fresh punch-in does not overlap.
+            $this->assertFalse(
+                $this->attendanceDao->checkForPunchInOverLappingRecordsForUpdate(
+                    new DateTime("2011-04-22 09:25:00", $utcTimeZone),
+                    5
+                )
+            );
+            // An overlapping time for the same employee is detected.
+            $this->assertTrue(
+                $this->attendanceDao->checkForPunchInOverLappingRecordsForUpdate(
+                    new DateTime("2011-04-21 09:26:00", $utcTimeZone),
+                    5
+                )
+            );
+            // Employee 4 is already punched in: a second punch-in must be rejected.
+            $this->expectException(AttendanceServiceException::class);
+            $this->attendanceDao->checkForPunchInOverLappingRecordsForUpdate(
+                new DateTime("2022-01-27 09:23:00", $utcTimeZone),
+                4
+            );
+        } finally {
+            $connection->rollBack();
+        }
     }
 
     public function testPunchOutOverlapRecords(): void

--- a/src/plugins/orangehrmClaimPlugin/Api/ClaimExpenseAPI.php
+++ b/src/plugins/orangehrmClaimPlugin/Api/ClaimExpenseAPI.php
@@ -201,7 +201,7 @@ class ClaimExpenseAPI extends Endpoint implements CrudEndpoint
                 RequestParams::PARAM_TYPE_ATTRIBUTE,
                 self::PARAMETER_REQUEST_ID
             );
-            $claimRequest = $this->getClaimRequest($requestId);
+            $claimRequest = $this->getClaimRequestForUpdate($requestId);
 
             $this->isActionAllowed(WorkflowStateMachine::CLAIM_ACTION_SUBMIT, $claimRequest);
 
@@ -304,22 +304,32 @@ class ClaimExpenseAPI extends Endpoint implements CrudEndpoint
      */
     public function delete(): EndpointResult
     {
-        $requestId = $this->getRequestParams()
-            ->getInt(RequestParams::PARAM_TYPE_ATTRIBUTE, self::PARAMETER_REQUEST_ID);
-        $claimRequest = $this->getClaimRequest($requestId);
+        $this->beginTransaction();
+        try {
+            $requestId = $this->getRequestParams()
+                ->getInt(RequestParams::PARAM_TYPE_ATTRIBUTE, self::PARAMETER_REQUEST_ID);
+            $claimRequest = $this->getClaimRequestForUpdate($requestId);
 
-        $this->isActionAllowed(WorkflowStateMachine::CLAIM_ACTION_SUBMIT, $claimRequest);
+            $this->isActionAllowed(WorkflowStateMachine::CLAIM_ACTION_SUBMIT, $claimRequest);
 
-        $ids = $this->getClaimService()->getClaimDao()->getExistingClaimExpenseIdsForRequestId(
-            $this->getRequestParams()->getArray(RequestParams::PARAM_TYPE_BODY, CommonParams::PARAMETER_IDS),
-            $requestId
-        );
-        $this->throwRecordNotFoundExceptionIfEmptyIds($ids);
-        $this->getClaimService()
-            ->getClaimDao()
-            ->deleteClaimExpense($requestId, $ids);
+            $ids = $this->getClaimService()->getClaimDao()->getExistingClaimExpenseIdsForRequestId(
+                $this->getRequestParams()->getArray(RequestParams::PARAM_TYPE_BODY, CommonParams::PARAMETER_IDS),
+                $requestId
+            );
+            $this->throwRecordNotFoundExceptionIfEmptyIds($ids);
+            $this->getClaimService()
+                ->getClaimDao()
+                ->deleteClaimExpense($requestId, $ids);
 
-        return new EndpointResourceResult(ArrayModel::class, $ids);
+            $this->commitTransaction();
+            return new EndpointResourceResult(ArrayModel::class, $ids);
+        } catch (ForbiddenException | InvalidParamException | RecordNotFoundException $e) {
+            $this->rollBackTransaction();
+            throw $e;
+        } catch (Exception $e) {
+            $this->rollBackTransaction();
+            throw new TransactionException($e);
+        }
     }
 
     /**

--- a/src/plugins/orangehrmClaimPlugin/Api/Traits/ClaimRequestAPIHelperTrait.php
+++ b/src/plugins/orangehrmClaimPlugin/Api/Traits/ClaimRequestAPIHelperTrait.php
@@ -61,6 +61,29 @@ trait ClaimRequestAPIHelperTrait
     {
         $claimRequest = $this->getClaimService()->getClaimDao()
             ->getClaimRequestById($requestId);
+        return $this->assertClaimRequestAccessible($claimRequest);
+    }
+
+    /**
+     * Same as getClaimRequest() but reads the claim request under a pessimistic write lock.
+     * Must be called inside an active transaction.
+     *
+     * @param int $requestId
+     * @return ClaimRequest
+     */
+    public function getClaimRequestForUpdate(int $requestId): ClaimRequest
+    {
+        $claimRequest = $this->getClaimService()->getClaimDao()
+            ->getClaimRequestByIdForUpdate($requestId);
+        return $this->assertClaimRequestAccessible($claimRequest);
+    }
+
+    /**
+     * @param ClaimRequest|null $claimRequest
+     * @return ClaimRequest
+     */
+    private function assertClaimRequestAccessible(?ClaimRequest $claimRequest): ClaimRequest
+    {
         $this->throwRecordNotFoundExceptionIfNotExist($claimRequest, ClaimRequest::class);
         if (!$this->getUserRoleManagerHelper()->isEmployeeAccessible($claimRequest->getEmployee()->getEmpNumber())) {
             throw $this->getForbiddenException();

--- a/src/plugins/orangehrmClaimPlugin/Dao/ClaimDao.php
+++ b/src/plugins/orangehrmClaimPlugin/Dao/ClaimDao.php
@@ -25,6 +25,7 @@ use OrangeHRM\Claim\Dto\ClaimExpenseSearchFilterParams;
 use OrangeHRM\Claim\Dto\ClaimExpenseTypeSearchFilterParams;
 use OrangeHRM\Claim\Dto\ClaimRequestSearchFilterParams;
 use OrangeHRM\Claim\Dto\PartialClaimAttachment;
+use Doctrine\DBAL\LockMode;
 use OrangeHRM\Core\Dao\BaseDao;
 use OrangeHRM\Entity\ClaimAttachment;
 use OrangeHRM\Entity\ClaimEvent;
@@ -338,6 +339,24 @@ class ClaimDao extends BaseDao
     public function getClaimRequestById(int $id): ?ClaimRequest
     {
         return $this->getRepository(ClaimRequest::class)->findOneBy(['id' => $id, 'isDeleted' => false]);
+    }
+
+    /**
+     * Read a claim request under a pessimistic write lock. Must be called within an
+     * active transaction.
+     *
+     * @param int $id
+     * @return ClaimRequest|null
+     */
+    public function getClaimRequestByIdForUpdate(int $id): ?ClaimRequest
+    {
+        $qb = $this->createQueryBuilder(ClaimRequest::class, 'claimRequest');
+        $qb->andWhere('claimRequest.id = :id')
+            ->setParameter('id', $id);
+        $qb->andWhere('claimRequest.isDeleted = :isDeleted')
+            ->setParameter('isDeleted', false);
+        $qb->getQuery()->setLockMode(LockMode::PESSIMISTIC_WRITE);
+        return $qb->getQuery()->getOneOrNullResult();
     }
 
     /**

--- a/src/plugins/orangehrmClaimPlugin/Dao/ClaimDao.php
+++ b/src/plugins/orangehrmClaimPlugin/Dao/ClaimDao.php
@@ -355,8 +355,9 @@ class ClaimDao extends BaseDao
             ->setParameter('id', $id);
         $qb->andWhere('claimRequest.isDeleted = :isDeleted')
             ->setParameter('isDeleted', false);
-        $qb->getQuery()->setLockMode(LockMode::PESSIMISTIC_WRITE);
-        return $qb->getQuery()->getOneOrNullResult();
+        $query = $qb->getQuery();
+        $query->setLockMode(LockMode::PESSIMISTIC_WRITE);
+        return $query->getOneOrNullResult();
     }
 
     /**

--- a/src/plugins/orangehrmClaimPlugin/test/Dao/ClaimDaoRequestTest.php
+++ b/src/plugins/orangehrmClaimPlugin/test/Dao/ClaimDaoRequestTest.php
@@ -19,6 +19,8 @@
 
 namespace OrangeHRM\Tests\Claim\Dao;
 
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\RetryableException;
 use Doctrine\ORM\TransactionRequiredException;
 use OrangeHRM\Claim\Dao\ClaimDao;
 use OrangeHRM\Claim\Dto\ClaimRequestSearchFilterParams;
@@ -79,6 +81,59 @@ class ClaimDaoRequestTest extends KernelTestCase
             $this->assertNull($this->claimDao->getClaimRequestByIdForUpdate(99999));
         } finally {
             $connection->rollBack();
+        }
+    }
+
+    /**
+     * Concurrency proof: the pessimistic write lock taken by getClaimRequestByIdForUpdate()
+     * must actually serialise concurrent writers, not just emit a FOR UPDATE clause the
+     * database ignores. Connection A (the EntityManager connection) holds the lock on claim
+     * request #1 inside an open transaction; a second, independent connection B then tries to
+     * lock the same row FOR UPDATE with a 1-second innodb_lock_wait_timeout. B must block on
+     * A's lock and fail with a retryable lock-contention error (lock wait timeout), which is
+     * the observable signature of the row being genuinely locked — the guard against the
+     * TOCTOU race where a concurrent submit slips an expense into an already-submitted claim.
+     *
+     * This also runs the FOR UPDATE read against the real database, so any version-specific
+     * incompatibility surfaces on every CI DB-compatibility matrix entry (MySQL / MariaDB).
+     */
+    public function testGetClaimRequestByIdForUpdateLocksRowAgainstConcurrentWriter(): void
+    {
+        $emConnection = Doctrine::getEntityManager()->getConnection();
+        $secondConnection = DriverManager::getConnection($emConnection->getParams());
+        // Fail fast instead of waiting the server default lock-wait timeout (often 50s).
+        $secondConnection->executeStatement('SET SESSION innodb_lock_wait_timeout = 1');
+
+        $emConnection->beginTransaction();
+        try {
+            // A: acquire the pessimistic write lock on claim request #1.
+            $locked = $this->claimDao->getClaimRequestByIdForUpdate(1);
+            $this->assertInstanceOf(ClaimRequest::class, $locked);
+
+            // B: a concurrent request tries to lock the same row the DAO locks.
+            $secondConnection->beginTransaction();
+            $lockContention = null;
+            try {
+                $secondConnection->executeQuery(
+                    'SELECT id FROM ohrm_claim_request WHERE id = ? AND is_deleted = 0 FOR UPDATE',
+                    [1]
+                );
+            } catch (RetryableException $e) {
+                $lockContention = $e;
+            }
+
+            $this->assertInstanceOf(
+                RetryableException::class,
+                $lockContention,
+                'A concurrent FOR UPDATE on the same claim request must block on the held lock '
+                . 'and fail with a lock wait timeout, proving the row is pessimistically locked.'
+            );
+        } finally {
+            if ($secondConnection->isTransactionActive()) {
+                $secondConnection->rollBack();
+            }
+            $secondConnection->close();
+            $emConnection->rollBack();
         }
     }
 }

--- a/src/plugins/orangehrmClaimPlugin/test/Dao/ClaimDaoRequestTest.php
+++ b/src/plugins/orangehrmClaimPlugin/test/Dao/ClaimDaoRequestTest.php
@@ -19,9 +19,12 @@
 
 namespace OrangeHRM\Tests\Claim\Dao;
 
+use Doctrine\ORM\TransactionRequiredException;
 use OrangeHRM\Claim\Dao\ClaimDao;
 use OrangeHRM\Claim\Dto\ClaimRequestSearchFilterParams;
 use OrangeHRM\Config\Config;
+use OrangeHRM\Entity\ClaimRequest;
+use OrangeHRM\ORM\Doctrine;
 use OrangeHRM\Tests\Util\KernelTestCase;
 use OrangeHRM\Tests\Util\TestDataService;
 
@@ -52,5 +55,30 @@ class ClaimDaoRequestTest extends KernelTestCase
         $claimRequestSearchFilterParams->setEmpNumbers([4]);
         $claimRequests = $this->claimDao->getClaimRequestList($claimRequestSearchFilterParams);
         $this->assertEquals(4, count($claimRequests));
+    }
+
+    /**
+     * The locked read must take a pessimistic write lock: Doctrine raises
+     * TransactionRequiredException when a pessimistic-write query is issued without an
+     * active transaction, which confirms the read is locked rather than a plain findOneBy().
+     */
+    public function testGetClaimRequestByIdForUpdateRequiresTransactionForLock(): void
+    {
+        $this->expectException(TransactionRequiredException::class);
+        $this->claimDao->getClaimRequestByIdForUpdate(1);
+    }
+
+    public function testGetClaimRequestByIdForUpdateReturnsRequestWithinTransaction(): void
+    {
+        $connection = Doctrine::getEntityManager()->getConnection();
+        $connection->beginTransaction();
+        try {
+            $result = $this->claimDao->getClaimRequestByIdForUpdate(1);
+            $this->assertInstanceOf(ClaimRequest::class, $result);
+            $this->assertEquals(1, $result->getId());
+            $this->assertNull($this->claimDao->getClaimRequestByIdForUpdate(99999));
+        } finally {
+            $connection->rollBack();
+        }
     }
 }

--- a/src/plugins/orangehrmRecruitmentPlugin/Api/CandidateAttachmentAPI.php
+++ b/src/plugins/orangehrmRecruitmentPlugin/Api/CandidateAttachmentAPI.php
@@ -147,7 +147,8 @@ class CandidateAttachmentAPI extends Endpoint implements CrudEndpoint
         return new ParamRuleCollection(
             new ParamRule(
                 self::PARAMETER_CANDIDATE_ID,
-                new Rule(Rules::ENTITY_ID_EXISTS, [Candidate::class])
+                new Rule(Rules::ENTITY_ID_EXISTS, [Candidate::class]),
+                new Rule(Rules::IN_ACCESSIBLE_ENTITY_ID, [Candidate::class])
             ),
             new ParamRule(
                 self::PARAMETER_ATTACHMENT,
@@ -225,7 +226,11 @@ class CandidateAttachmentAPI extends Endpoint implements CrudEndpoint
     public function getValidationRuleForGetOne(): ParamRuleCollection
     {
         return new ParamRuleCollection(
-            new ParamRule(self::PARAMETER_CANDIDATE_ID),
+            new ParamRule(
+                self::PARAMETER_CANDIDATE_ID,
+                new Rule(Rules::POSITIVE),
+                new Rule(Rules::IN_ACCESSIBLE_ENTITY_ID, [Candidate::class])
+            ),
         );
     }
 
@@ -309,6 +314,7 @@ class CandidateAttachmentAPI extends Endpoint implements CrudEndpoint
             new ParamRule(
                 self::PARAMETER_CANDIDATE_ID,
                 new Rule(Rules::POSITIVE),
+                new Rule(Rules::IN_ACCESSIBLE_ENTITY_ID, [Candidate::class])
             ),
             new ParamRule(
                 self::PARAMETER_CURRENT_ATTACHMENT,

--- a/src/plugins/orangehrmRecruitmentPlugin/test/Api/CandidateAttachmentAPITest.php
+++ b/src/plugins/orangehrmRecruitmentPlugin/test/Api/CandidateAttachmentAPITest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OrangeHRM.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OrangeHRM\Tests\Recruitment\Api;
+
+use OrangeHRM\Core\Api\V2\Validator\ParamRule;
+use OrangeHRM\Core\Api\V2\Validator\ParamRuleCollection;
+use OrangeHRM\Core\Api\V2\Validator\Rules;
+use OrangeHRM\Entity\Candidate;
+use OrangeHRM\Recruitment\Api\CandidateAttachmentAPI;
+use OrangeHRM\Tests\Util\EndpointTestCase;
+
+/**
+ * @group Recruitment
+ * @group APIv2
+ */
+class CandidateAttachmentAPITest extends EndpointTestCase
+{
+    /**
+     * GET /api/v2/recruitment/candidate/{candidateId}/attachment must enforce per-record
+     * access scope so a HiringManager/Interviewer cannot read attachment metadata of
+     * candidates outside their accessible vacancies.
+     */
+    public function testGetValidationRuleForGetOneEnforcesCandidateAccessScope(): void
+    {
+        $api = new CandidateAttachmentAPI($this->getRequest());
+        $this->assertCandidateIdGatedByAccessibleEntityRule($api->getValidationRuleForGetOne());
+    }
+
+    /**
+     * PUT /api/v2/recruitment/candidate/{candidateId}/attachment (which can permanently
+     * delete a resume via currentAttachment=deleteCurrent) must enforce per-record access scope.
+     */
+    public function testGetValidationRuleForUpdateEnforcesCandidateAccessScope(): void
+    {
+        $api = new CandidateAttachmentAPI($this->getRequest());
+        $this->assertCandidateIdGatedByAccessibleEntityRule($api->getValidationRuleForUpdate());
+    }
+
+    /**
+     * POST /api/v2/recruitment/candidate/attachments must enforce per-record access scope too,
+     * so an attachment cannot be created against a candidate the user cannot access.
+     */
+    public function testGetValidationRuleForCreateEnforcesCandidateAccessScope(): void
+    {
+        $api = new CandidateAttachmentAPI($this->getRequest());
+        $this->assertCandidateIdGatedByAccessibleEntityRule($api->getValidationRuleForCreate());
+    }
+
+    private function assertCandidateIdGatedByAccessibleEntityRule(ParamRuleCollection $collection): void
+    {
+        $candidateIdRule = null;
+        foreach ($collection->getParamValidations() as $paramRule) {
+            if ($paramRule instanceof ParamRule
+                && $paramRule->getParamKey() === CandidateAttachmentAPI::PARAMETER_CANDIDATE_ID) {
+                $candidateIdRule = $paramRule;
+                break;
+            }
+        }
+
+        $this->assertNotNull(
+            $candidateIdRule,
+            'Expected a validation rule for the candidateId parameter'
+        );
+
+        $hasAccessibleEntityRule = false;
+        foreach ($candidateIdRule->getRules() as $rule) {
+            if ($rule->getRuleClass() === Rules::IN_ACCESSIBLE_ENTITY_ID
+                && in_array(Candidate::class, $rule->getRuleConstructorParams(), true)) {
+                $hasAccessibleEntityRule = true;
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $hasAccessibleEntityRule,
+            'candidateId must be guarded by an IN_ACCESSIBLE_ENTITY_ID rule against Candidate::class '
+            . 'to prevent cross-candidate access'
+        );
+    }
+}

--- a/src/plugins/orangehrmRecruitmentPlugin/test/Api/CandidateAttachmentAPITest.php
+++ b/src/plugins/orangehrmRecruitmentPlugin/test/Api/CandidateAttachmentAPITest.php
@@ -19,12 +19,17 @@
 
 namespace OrangeHRM\Tests\Recruitment\Api;
 
+use OrangeHRM\Config\Config;
+use OrangeHRM\Core\Api\V2\Exception\ForbiddenException;
 use OrangeHRM\Core\Api\V2\Validator\ParamRule;
 use OrangeHRM\Core\Api\V2\Validator\ParamRuleCollection;
 use OrangeHRM\Core\Api\V2\Validator\Rules;
+use OrangeHRM\Core\Authorization\Manager\BasicUserRoleManager;
 use OrangeHRM\Entity\Candidate;
+use OrangeHRM\Framework\Services;
 use OrangeHRM\Recruitment\Api\CandidateAttachmentAPI;
 use OrangeHRM\Tests\Util\EndpointTestCase;
+use OrangeHRM\Tests\Util\TestDataService;
 
 /**
  * @group Recruitment
@@ -32,6 +37,28 @@ use OrangeHRM\Tests\Util\EndpointTestCase;
  */
 class CandidateAttachmentAPITest extends EndpointTestCase
 {
+    /**
+     * Candidate the mocked role manager can access.
+     */
+    private const ACCESSIBLE_CANDIDATE_ID = 1;
+
+    /**
+     * Candidate that exists but is OUTSIDE the user's accessible scope — the IDOR target.
+     */
+    private const INACCESSIBLE_CANDIDATE_ID = 2;
+
+    protected function setUp(): void
+    {
+        $fixture = Config::get(Config::PLUGINS_DIR)
+            . '/orangehrmRecruitmentPlugin/test/fixtures/CandidateAttachmentEntityTest.yaml';
+        TestDataService::populate($fixture);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Structural guards: the candidateId param must be wired with an IN_ACCESSIBLE_ENTITY_ID rule.
+    // Cheap and fast — they fail immediately if the rule is removed or pointed at the wrong entity.
+    // ---------------------------------------------------------------------------------------------
+
     /**
      * GET /api/v2/recruitment/candidate/{candidateId}/attachment must enforce per-record
      * access scope so a HiringManager/Interviewer cannot read attachment metadata of
@@ -63,16 +90,79 @@ class CandidateAttachmentAPITest extends EndpointTestCase
         $this->assertCandidateIdGatedByAccessibleEntityRule($api->getValidationRuleForCreate());
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Behavioural enforcement: drive the actual candidateId rule the API builds through the
+    // validator. With a role manager that only grants access to ACCESSIBLE_CANDIDATE_ID, an
+    // existing-but-inaccessible candidate must be rejected with ForbiddenException (the IDOR the
+    // fix closes), while the accessible candidate passes. A structural assertion alone would not
+    // catch the rule being wired with the wrong entity, a wrong option, or the validator failing
+    // to enforce it.
+    // ---------------------------------------------------------------------------------------------
+
+    public function testGetOneRejectsAttachmentAccessForInaccessibleCandidate(): void
+    {
+        $api = new CandidateAttachmentAPI($this->getRequest());
+        $this->assertCandidateIdAccessScopeIsEnforced($api->getValidationRuleForGetOne());
+    }
+
+    public function testUpdateRejectsAttachmentMutationForInaccessibleCandidate(): void
+    {
+        $api = new CandidateAttachmentAPI($this->getRequest());
+        $this->assertCandidateIdAccessScopeIsEnforced($api->getValidationRuleForUpdate());
+    }
+
+    public function testCreateRejectsAttachmentForInaccessibleCandidate(): void
+    {
+        $api = new CandidateAttachmentAPI($this->getRequest());
+        $this->assertCandidateIdAccessScopeIsEnforced($api->getValidationRuleForCreate());
+    }
+
+    /**
+     * Runs the candidateId param rule (exactly as the API built it) through the validator under a
+     * role manager scoped to a single candidate, asserting the accessible candidate passes and the
+     * existing inaccessible candidate is blocked with ForbiddenException.
+     */
+    private function assertCandidateIdAccessScopeIsEnforced(ParamRuleCollection $collection): void
+    {
+        $userRoleManager = $this->getMockBuilder(BasicUserRoleManager::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAccessibleEntityIds'])
+            ->getMock();
+        $userRoleManager->method('getAccessibleEntityIds')
+            ->willReturn([self::ACCESSIBLE_CANDIDATE_ID]);
+        $this->createKernelWithMockServices([Services::USER_ROLE_MANAGER => $userRoleManager]);
+
+        // Validate only the candidateId rule the API wired — isolating the access-scope guard from
+        // the other params (attachment, currentAttachment) the create/update collections require.
+        $candidateIdRules = new ParamRuleCollection($this->getCandidateIdParamRule($collection));
+
+        $this->assertTrue(
+            $this->validate(
+                [CandidateAttachmentAPI::PARAMETER_CANDIDATE_ID => self::ACCESSIBLE_CANDIDATE_ID],
+                $candidateIdRules
+            ),
+            'An accessible candidate must pass the candidateId access-scope check'
+        );
+
+        $forbidden = null;
+        try {
+            $this->validate(
+                [CandidateAttachmentAPI::PARAMETER_CANDIDATE_ID => self::INACCESSIBLE_CANDIDATE_ID],
+                $candidateIdRules
+            );
+        } catch (ForbiddenException $e) {
+            $forbidden = $e;
+        }
+        $this->assertInstanceOf(
+            ForbiddenException::class,
+            $forbidden,
+            'Accessing an existing candidate outside the user\'s scope must be forbidden (IDOR guard)'
+        );
+    }
+
     private function assertCandidateIdGatedByAccessibleEntityRule(ParamRuleCollection $collection): void
     {
-        $candidateIdRule = null;
-        foreach ($collection->getParamValidations() as $paramRule) {
-            if ($paramRule instanceof ParamRule
-                && $paramRule->getParamKey() === CandidateAttachmentAPI::PARAMETER_CANDIDATE_ID) {
-                $candidateIdRule = $paramRule;
-                break;
-            }
-        }
+        $candidateIdRule = $this->getCandidateIdParamRule($collection);
 
         $this->assertNotNull(
             $candidateIdRule,
@@ -93,5 +183,16 @@ class CandidateAttachmentAPITest extends EndpointTestCase
             'candidateId must be guarded by an IN_ACCESSIBLE_ENTITY_ID rule against Candidate::class '
             . 'to prevent cross-candidate access'
         );
+    }
+
+    private function getCandidateIdParamRule(ParamRuleCollection $collection): ?ParamRule
+    {
+        foreach ($collection->getParamValidations() as $paramRule) {
+            if ($paramRule instanceof ParamRule
+                && $paramRule->getParamKey() === CandidateAttachmentAPI::PARAMETER_CANDIDATE_ID) {
+                return $paramRule;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Three security fixes, each driven by a regression test (TDD).

- **Claim expense** — read the claim status under a pessimistic write lock and wrap `delete()` in a transaction, so a concurrent submit can't slip an expense into an already-submitted claim.
- **Attendance punch-in** — run the overlap check under a write lock inside a transaction, so concurrent punch-ins can't both pass and create duplicate open records.
- **Candidate attachment** — enforce per-record access scope (`IN_ACCESSIBLE_ENTITY_ID` against `Candidate`) on get/update/create, so attachments can't be read or deleted for candidates the user can't access.

Suites pass: Claim 254, Attendance 225, Recruitment Api/Dao 210.