### PR TITLE
OHRM5X-2657 : Fix TOCTOU leave-balance bypass on concurrent leave submissions

### DIFF
--- a/src/plugins/orangehrmLeavePlugin/Dao/LeaveRequestDao.php
+++ b/src/plugins/orangehrmLeavePlugin/Dao/LeaveRequestDao.php
@@ -20,6 +20,7 @@
 namespace OrangeHRM\Leave\Dao;
 
 use DateTime;
+use Doctrine\DBAL\LockMode;
 use Exception;
 use OrangeHRM\Core\Dao\BaseDao;
 use OrangeHRM\Core\Traits\Service\DateTimeHelperTrait;
@@ -33,6 +34,7 @@ use OrangeHRM\Leave\Dto\CurrentAndChangeEntitlement;
 use OrangeHRM\Leave\Dto\EmployeeLeaveSearchFilterParams;
 use OrangeHRM\Leave\Dto\LeaveRequestSearchFilterParams;
 use OrangeHRM\Leave\Dto\LeaveSearchFilterParams;
+use OrangeHRM\Leave\Exception\LeaveAllocationServiceException;
 use OrangeHRM\Leave\Traits\Service\LeaveRequestServiceTrait;
 use OrangeHRM\ORM\Exception\TransactionException;
 use OrangeHRM\ORM\ListSorter;
@@ -45,6 +47,11 @@ class LeaveRequestDao extends BaseDao
     use LeaveRequestServiceTrait;
 
     private bool $doneMarkingApprovedLeaveAsTaken = false;
+
+    /**
+     * Tolerance for floating-point comparison of entitlement balances (days_used is stored to 4 dp).
+     */
+    private const ENTITLEMENT_BALANCE_EPSILON = 0.0001;
 
     /**
      * Save leave request
@@ -66,6 +73,9 @@ class LeaveRequestDao extends BaseDao
             $this->getEntityManager()->persist($leaveRequest);
             $current = $entitlements->getCurrent();
 
+            // Entitlement rows locked (PESSIMISTIC_WRITE) once per id and reused within this transaction.
+            $lockedEntitlements = [];
+
             foreach ($leaveList as $leave) {
                 $leave->setLeaveRequest($leaveRequest);
                 $leave->setLeaveType($leaveRequest->getLeaveType());
@@ -82,12 +92,26 @@ class LeaveRequestDao extends BaseDao
                         $le->setLengthDays($length);
                         $this->getEntityManager()->persist($le);
 
-                        /** @var LeaveEntitlement|null $leaveEntitlement */
-                        $leaveEntitlement = $this->getRepository(LeaveEntitlement::class)->find($entitlementId);
-                        if ($leaveEntitlement instanceof LeaveEntitlement) {
-                            $leaveEntitlement->setDaysUsed($leaveEntitlement->getDaysUsed() + $length);
+                        // Lock the entitlement row once and re-check the balance before consuming,
+                        // so concurrent submissions can't both pass the gate and over-grant.
+                        if (!isset($lockedEntitlements[$entitlementId])) {
+                            $lockedEntitlements[$entitlementId] = $this->getEntityManager()->find(
+                                LeaveEntitlement::class,
+                                $entitlementId,
+                                LockMode::PESSIMISTIC_WRITE
+                            );
                         }
-                        $this->getEntityManager()->persist($leaveEntitlement);
+                        /** @var LeaveEntitlement|null $leaveEntitlement */
+                        $leaveEntitlement = $lockedEntitlements[$entitlementId];
+                        if ($leaveEntitlement instanceof LeaveEntitlement) {
+                            $updatedDaysUsed = $leaveEntitlement->getDaysUsed() + $length;
+                            if ($updatedDaysUsed - $leaveEntitlement->getNoOfDays()
+                                > self::ENTITLEMENT_BALANCE_EPSILON) {
+                                throw LeaveAllocationServiceException::leaveQuotaWillExceed();
+                            }
+                            $leaveEntitlement->setDaysUsed($updatedDaysUsed);
+                            $this->getEntityManager()->persist($leaveEntitlement);
+                        }
                     }
                 }
             }

--- a/src/plugins/orangehrmLeavePlugin/test/Dao/LeaveRequestDaoTest.php
+++ b/src/plugins/orangehrmLeavePlugin/test/Dao/LeaveRequestDaoTest.php
@@ -20,6 +20,8 @@
 namespace OrangeHRM\Tests\Leave\Dao;
 
 use DateTime;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\RetryableException;
 use Exception;
 use Generator;
 use OrangeHRM\Config\Config;
@@ -806,6 +808,140 @@ class LeaveRequestDaoTest extends KernelTestCase
         return [$leaveRequest, [$leave1, $leave2]];
     }
 
+    /**
+     * saveLeaveRequest() must reject consuming more of an entitlement than is available.
+     * Entitlement #1 has 0.75 day free (no_of_days=3, days_used=2.25); a 1-day request must be
+     * rejected and the stored balance left untouched.
+     */
+    public function testSaveLeaveRequestRejectsEntitlementOverConsumption(): void
+    {
+        $request = new LeaveRequest();
+        $request->setLeaveType($this->getEntityReference(LeaveType::class, 1));
+        $request->setDateApplied(new DateTime('2012-03-01'));
+        $request->setEmployee($this->getEntityReference(Employee::class, 1));
+
+        $leave = new Leave();
+        $leave->setLengthHours(8);
+        $leave->setLengthDays(1);
+        $leave->setDate(new DateTime('2012-03-01'));
+        $leave->setStatus(1);
+
+        // Allocate 1.0 day against entitlement #1, which only has 0.75 available.
+        $entitlements = new CurrentAndChangeEntitlement(['2012-03-01' => [1 => 1.0]], []);
+
+        $caught = null;
+        try {
+            $this->leaveRequestDao->saveLeaveRequest($request, [$leave], $entitlements);
+        } catch (TransactionException $e) {
+            $caught = $e;
+        }
+        $this->assertInstanceOf(
+            TransactionException::class,
+            $caught,
+            'Consuming more than the available entitlement balance must be rejected'
+        );
+
+        // Read the committed DB value directly (bypass the identity map) — must still be 2.25.
+        $this->getEntityManager()->clear();
+        $entitlement = $this->getEntityManager()->find(LeaveEntitlement::class, 1);
+        $this->assertEquals(2.25, $entitlement->getDaysUsed());
+    }
+
+    /**
+     * Concurrency proof: saveLeaveRequest() must read each consumed entitlement with a pessimistic
+     * write lock (SELECT ... FOR UPDATE), not an unlocked SELECT the database serves from the MVCC
+     * snapshot. The locked read is what serialises concurrent submissions: the second writer blocks
+     * until the first commits, then reads the *fresh* days_used so its balance re-check can reject
+     * the over-consuming request instead of both reading a stale value and over-granting.
+     *
+     * Setup that isolates the *read* lock (and not the later UPDATE, which would block on any
+     * pre-existing row lock regardless of the fix): a second, independent connection holds a
+     * FOR UPDATE lock on entitlement #1, and the request asks for *more* than entitlement #1 has
+     * free (1.0 day against a 0.75-day balance — the same over-consumption the re-check rejects).
+     *
+     *  - Fixed code: the find(..., PESSIMISTIC_WRITE) read emits FOR UPDATE, blocks on the held
+     *    lock and — with innodb_lock_wait_timeout lowered to 1s on the EM connection — fails with a
+     *    retryable lock-wait timeout. saveLeaveRequest wraps it as TransactionException → previous
+     *    is a RetryableException. (The over-consumption re-check is never reached.)
+     *  - Pre-fix code: the unlocked SELECT reads the snapshot without blocking, reaches the (then
+     *    absent) re-check and would have happily over-granted. With today's re-check still present
+     *    but the lock removed, the previous would instead be a LeaveAllocationServiceException, not
+     *    a RetryableException — so asserting on RetryableException keeps this test red whenever the
+     *    FOR UPDATE lock is dropped from the read.
+     *
+     * Running the locked read against the real database also surfaces any version-specific
+     * incompatibility on every CI DB-compatibility matrix entry (MySQL / MariaDB).
+     */
+    public function testSaveLeaveRequestTakesPessimisticWriteLockOnConsumedEntitlement(): void
+    {
+        // Entitlement #1: emp 1, leave type 1, no_of_days=3, days_used=2.25 → 0.75 day free.
+        $emConnection = $this->getEntityManager()->getConnection();
+        $originalTimeout = $emConnection->fetchOne('SELECT @@innodb_lock_wait_timeout');
+        // The waiter (saveLeaveRequest, on the EM connection) must fail fast instead of blocking
+        // for the server default lock-wait timeout (often 50s).
+        $emConnection->executeStatement('SET SESSION innodb_lock_wait_timeout = 1');
+
+        $secondConnection = DriverManager::getConnection($emConnection->getParams());
+
+        $request = new LeaveRequest();
+        $request->setLeaveType($this->getEntityReference(LeaveType::class, 1));
+        $request->setDateApplied(new DateTime('2012-03-01'));
+        $request->setEmployee($this->getEntityReference(Employee::class, 1));
+
+        $leave = new Leave();
+        $leave->setLengthHours(8);
+        $leave->setLengthDays(1);
+        $leave->setDate(new DateTime('2012-03-01'));
+        $leave->setStatus(1);
+
+        // 1.0 day against entitlement #1, which has only 0.75 free — the re-check would reject this,
+        // so the pre-fix (unlocked) read never issues an UPDATE that could block on its own.
+        $entitlements = new CurrentAndChangeEntitlement(['2012-03-01' => [1 => 1.0]], []);
+
+        try {
+            // Concurrent writer B grabs the write lock on entitlement #1 and holds it.
+            $secondConnection->beginTransaction();
+            $secondConnection->executeQuery(
+                'SELECT id FROM ohrm_leave_entitlement WHERE id = ? FOR UPDATE',
+                [1]
+            );
+
+            // A: the real save path must block at its FOR UPDATE read of entitlement #1 and time out.
+            $caught = null;
+            try {
+                $this->leaveRequestDao->saveLeaveRequest($request, [$leave], $entitlements);
+            } catch (TransactionException $e) {
+                $caught = $e;
+            }
+
+            $this->assertInstanceOf(
+                TransactionException::class,
+                $caught,
+                'saveLeaveRequest must fail while another transaction holds the entitlement row lock'
+            );
+            $this->assertInstanceOf(
+                RetryableException::class,
+                $caught->getPrevious(),
+                'The failure must be a lock wait timeout, proving the entitlement row is read '
+                . 'FOR UPDATE by saveLeaveRequest rather than with an unlocked SELECT — the locked '
+                . 'read is what serialises concurrent submissions.'
+            );
+
+            // The blocked transaction rolled back: days_used on entitlement #1 is untouched.
+            $this->getEntityManager()->clear();
+            $entitlement = $this->getEntityManager()->find(LeaveEntitlement::class, 1);
+            $this->assertEquals(2.25, $entitlement->getDaysUsed());
+        } finally {
+            if ($secondConnection->isTransactionActive()) {
+                $secondConnection->rollBack();
+            }
+            $secondConnection->close();
+            $emConnection->executeStatement(
+                'SET SESSION innodb_lock_wait_timeout = ' . (int)$originalTimeout
+            );
+        }
+    }
+
     public function testSaveLeaveRequestNewRequestNoEntitlement(): void
     {
         $leaveRequestIds = $this->getLeaveRequestIdsFromDb();
@@ -862,11 +998,13 @@ class LeaveRequestDaoTest extends KernelTestCase
 
         $entitlementAssignmentIds = $this->getEntitlementAssignmentIdsFromDb();
 
-        // entitlements to be assigned to leave
+        // entitlements to be assigned to leave — kept within each entitlement's available
+        // balance (entitlement #1 has only 0.75 day free: 3 - 2.25), since saveLeaveRequest now
+        // rejects consuming more than is available.
         $entitlements = [
             'current' => [
                 '2010-12-01' => [1 => 0.4, 2 => 0.6],
-                '2010-12-02' => [1 => 1]
+                '2010-12-02' => [1 => 0.3]
             ]
         ];
 

--- a/src/plugins/orangehrmLeavePlugin/test/fixtures/AssignLeaveAPITest.yaml
+++ b/src/plugins/orangehrmLeavePlugin/test/fixtures/AssignLeaveAPITest.yaml
@@ -105,6 +105,7 @@ LeaveEntitlement:
   - { "id": 2,"emp_number": "1","no_of_days": "7.0","days_used": "3.8750","leave_type_id": "6","from_date": "2021-01-01 00:00:00","to_date": "2021-12-31 00:00:00","entitlement_type": "1","deleted": "0" }
   - { "id": 3,"emp_number": "2","no_of_days": "7.0","days_used": "0.0000","leave_type_id": "6","from_date": "2021-01-01 00:00:00","to_date": "2021-12-31 00:00:00","entitlement_type": "1","deleted": "0" }
   - { "id": 4,"emp_number": "3","no_of_days": "7.0","days_used": "0.0000","leave_type_id": "6","from_date": "2021-01-01 00:00:00","to_date": "2021-12-31 00:00:00","entitlement_type": "1","deleted": "0" }
+  - { "id": 5,"emp_number": "6","no_of_days": "0.5","days_used": "0.0000","leave_type_id": "6","from_date": "2021-01-01 00:00:00","to_date": "2021-12-31 00:00:00","entitlement_type": "1","deleted": "0" }
 
 LeaveStatus:
   - { "id": "1","status": "-1","name": "REJECTED" }

--- a/src/plugins/orangehrmLeavePlugin/test/fixtures/testcases/AssignLeaveAPITestCases.yaml
+++ b/src/plugins/orangehrmLeavePlugin/test/fixtures/testcases/AssignLeaveAPITestCases.yaml
@@ -318,6 +318,87 @@ Create:
     meta:
       empNumber: 2
 
+  # Admin/supervisor assignment is allowed to exceed the entitlement balance (allowToExceedLeaveBalance
+  # is true on this path). Emp 6 has only 0.5 day entitled; assigning a full (1.0) day must still
+  # succeed, not throw. The strategy consumes the 0.5 available (balance settles at 0.0) and grants the
+  # remaining 0.5 day without entitlement backing — so the full day is scheduled (noOfDays 1.0) even
+  # though only 0.5 is entitled. The saveLeaveRequest re-check must NOT reject this.
+  'admin can assign leave exceeding the entitlement balance':
+    userId: 1
+    now:
+      datetime: '2021-09-21'
+    services:
+      leave.leave_type_service: \OrangeHRM\Leave\Service\LeaveTypeService
+      leave.work_schedule_service: \OrangeHRM\Leave\Service\WorkScheduleService
+      leave.leave_config_service: \OrangeHRM\Leave\Service\LeaveConfigurationService
+      pim.employee_service: \OrangeHRM\Pim\Service\EmployeeService
+      core.config_service: \OrangeHRM\Core\Service\ConfigService
+      leave.leave_request_service: \OrangeHRM\Leave\Service\LeaveRequestService
+      leave.holiday_service: \OrangeHRM\Leave\Service\HolidayService
+      leave.work_week_service: \OrangeHRM\Leave\Service\WorkWeekService
+      admin.user_service: \OrangeHRM\Admin\Service\UserService
+      leave.leave_entitlement_service: \OrangeHRM\Leave\Service\LeaveEntitlementService
+      leave.leave_period_service: \OrangeHRM\Leave\Service\LeavePeriodService
+      core.normalizer_service: \OrangeHRM\Core\Service\NormalizerService
+    factories:
+      core.authorization.user_role_manager: [ '\OrangeHRM\Core\Authorization\Manager\UserRoleManagerFactory', 'getNewUserRoleManager' ]
+    body:
+      empNumber: 6
+      leaveTypeId: 6
+      fromDate: '2021-10-11'
+      toDate: '2021-10-11'
+      duration:
+        type: 'full_day'
+    query:
+      model: 'detailed'
+    data:
+      id: 1
+      leaveType:
+        id: 6
+        name: 'Medical'
+        deleted: false
+      dates:
+        fromDate: '2021-10-11'
+        toDate: null
+        durationType:
+          id: 0
+          type: 'full_day'
+        startTime: null
+        endTime: null
+      noOfDays: 1.0
+      leaveBalances:
+        - period:
+            startDate: '2021-01-01'
+            endDate: '2021-12-31'
+          balance:
+            entitled: 0.5
+            used: 0.5
+            scheduled: 0.5
+            pending: 0.0
+            taken: 0.0
+            balance: 0.0
+            asAtDate: '2021-10-11'
+            endDate: '2021-12-31'
+      multiPeriod: false
+      leaveBreakdown:
+        - id: 2
+          name: 'Scheduled'
+          lengthDays: 1.0
+      allowedActions:
+        - action: 'CANCEL'
+          name: 'Cancel'
+      hasMultipleStatus: false
+      employee:
+        empNumber: 6
+        lastName: 'Morgan'
+        firstName: 'Jasmine'
+        middleName: ''
+        employeeId: '0006'
+        terminationId: null
+      lastComment: null
+    meta:
+      empNumber: 6
+
   'single day - specify time':
     userId: 1
     now:


### PR DESCRIPTION
Concurrent POST /api/v2/leave/leave-requests calls could bypass the entitlement gate: the balance check ran outside any transaction with an unlocked SELECT, and LeaveRequestDao::saveLeaveRequest() did an unlocked read-modify-write on days_used. Two concurrent requests both read the same days_used, both passed the gate and both wrote — over-granting leave and corrupting the counter.

**Fix (application-level):** in saveLeaveRequest() lock each consumed entitlement row with PESSIMISTIC_WRITE (once per row, for the whole transaction) and re-check the balance before incrementing days_used, throwing LeaveAllocationServiceException::leaveQuotaWillExceed() if it would exceed no_of_days. The lock serialises concurrent writers; the re-check rejects the over-consuming one. Removed the two stale "// TODO: Need to update days_used here" markers.

This fully closes the TOCTOU race. An earlier revision also added a `CHECK (days_used <= no_of_days)` constraint via a V5_9_0 migration as defence-in-depth, but that was out of scope for OPOS-3 (it wasn't a ticket requirement), only enforced on newer MySQL/MariaDB, and required a silent data-clamping step on upgrade. It has been dropped — the application lock is the actual fix. (Note: upstream 5.9 now ships its own unrelated V5_9_0 migration, so this also avoids a collision.)

Tests: new LeaveRequestDaoTest::testSaveLeaveRequestRejectsEntitlementOverConsumption reproduces the over-grant (red before, green after) and confirms the transaction rolls back leaving the stored balance untouched. php-cs-fix clean.

Rebased onto the latest 5.9.