### PR TITLE
OHRM5X-2646: Fix save & status language string disappearing

### DIFF
--- a/installer/Migration/V5_9_0/lang-string/admin.yaml
+++ b/installer/Migration/V5_9_0/lang-string/admin.yaml
@@ -88,11 +88,6 @@ langStrings:
     value: 'Employees on Leave Today'
     unitId: workspace_notification_event_leave_today
 
-  # Status
-  -
-    value: 'Status'
-    unitId: status
-
   # Table empty-state + cron hint
   -
     value: 'No registrations yet. Fill the form above and click + Add Registration to create one.'
@@ -113,9 +108,6 @@ langStrings:
   -
     value: 'Another registration already targets the same event type, workspace channel, and subunit. Saving this will cause the same message to be sent more than once per day. Do you want to save anyway?'
     unitId: workspace_notification_duplicate_dialog_subtitle
-  -
-    value: 'Save'
-    unitId: workspace_notification_save_anyway
   -
     value: 'Go back and edit'
     unitId: workspace_notification_go_back_and_fix

--- a/src/client/src/orangehrmAdminPlugin/pages/workspaceNotification/WorkspaceNotificationConfiguration.vue
+++ b/src/client/src/orangehrmAdminPlugin/pages/workspaceNotification/WorkspaceNotificationConfiguration.vue
@@ -224,7 +224,7 @@
       ref="duplicateDialog"
       :title="$t('admin.workspace_notification_duplicate_dialog_title')"
       :subtitle="$t('admin.workspace_notification_duplicate_dialog_subtitle')"
-      :confirm-label="$t('admin.workspace_notification_save_anyway')"
+      :confirm-label="$t('general.save')"
       :cancel-label="$t('admin.workspace_notification_go_back_and_fix')"
       icon="warning"
     ></confirmation-dialog>


### PR DESCRIPTION
…ation

V5_9_0/lang-string/admin.yaml introduced admin-group strings with values 'Save' and 'Status', which already exist in the general group. The install-time LangStringHelper::insertOrUpdateLangStrings() matches an existing lang string by value alone (ignoring the group), so it found general.save / general.status and reassigned those rows to the admin group, destroying the general keys. $t('general.save') then stopped resolving and every shared SubmitButton rendered without a label, failing all Save-form Cypress feature specs (admin emp status, job categories, job titles; leave period, leave types, work week).

Remove the duplicate admin strings so they no longer collide with the general group:
- 'Status' (unit_id status) was unused; drop it.
- 'Save' (unit_id workspace_notification_save_anyway) was the confirm label on the duplicate-registration dialog; point that confirm-label at the existing general.save instead.