### PR TITLE
OHRM5X-2661: Validate OIDC provider URL at write time to prevent SSRF

### DIFF
--- a/installer/Migration/V5_9_0/Migration.php
+++ b/installer/Migration/V5_9_0/Migration.php
@@ -38,6 +38,20 @@ class Migration extends AbstractMigration
         $this->insertWorkspaceNotificationMenuItem();
 
         $this->getLangStringHelper()->insertOrUpdateLangStrings(__DIR__, 'admin');
+
+        $this->seedOidcPrivateProviderHostsConfig();
+    }
+
+    /**
+     * Seed the OIDC provider-URL SSRF opt-out (default off). The application already treats an
+     * absent key as off, so this only makes the setting discoverable in hs_hr_config; seed only
+     * when missing so an admin who has already enabled it is not reset.
+     */
+    private function seedOidcPrivateProviderHostsConfig(): void
+    {
+        if ($this->getConfigHelper()->getConfigValue('oidc.allow_private_provider_hosts') === null) {
+            $this->getConfigHelper()->setConfigValue('oidc.allow_private_provider_hosts', 'No');
+        }
     }
 
     private function getLangStringHelper(): LangStringHelper

--- a/src/plugins/orangehrmCorePlugin/Service/ConfigService.php
+++ b/src/plugins/orangehrmCorePlugin/Service/ConfigService.php
@@ -47,6 +47,7 @@ class ConfigService
     public const KEY_ADMIN_DEFAULT_WORKSHIFT_START_TIME = 'admin.default_workshift_start_time';
     public const KEY_ADMIN_DEFAULT_WORKSHIFT_END_TIME = 'admin.default_workshift_end_time';
     public const KEY_OPENID_PROVIDER_ADDED = 'openId.provider.added';
+    public const KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS = 'oidc.allow_private_provider_hosts';
     public const KEY_OPEN_SOURCE_INTEGRATIONS = 'open_source_integrations';
     public const KEY_INSTANCE_IDENTIFIER = 'instance.identifier';
     public const KEY_SENDMAIL_PATH = 'email_config.sendmail_path';
@@ -391,6 +392,27 @@ class ConfigService
     public function setOpenIdProviderAdded($value = 'off'): void
     {
         $this->_setConfigValue(self::KEY_OPENID_PROVIDER_ADDED, $value);
+    }
+
+    /**
+     * Whether OIDC provider URLs are allowed to resolve to private/internal network addresses.
+     * Defaults to false (secure): provider URLs pointing at private/reserved/loopback/link-local/
+     * metadata/CGNAT ranges are rejected to prevent SSRF. Admins running an OIDC provider on an
+     * internal network (e.g. self-hosted Keycloak) can opt in by setting this config to 'Yes'.
+     *
+     * @return bool
+     */
+    public function isOidcPrivateProviderHostAllowed(): bool
+    {
+        return $this->_getConfigValue(self::KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS) === 'Yes';
+    }
+
+    /**
+     * @param bool $allowed
+     */
+    public function setOidcPrivateProviderHostAllowed(bool $allowed): void
+    {
+        $this->_setConfigValue(self::KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS, $allowed ? 'Yes' : 'No');
     }
 
     /**

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/Api/ProviderAPI.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/Api/ProviderAPI.php
@@ -42,6 +42,7 @@ use OrangeHRM\Entity\OpenIdProvider;
 use OrangeHRM\OpenidAuthentication\Api\Model\ProviderModel;
 use OrangeHRM\OpenidAuthentication\Dto\ProviderSearchFilterParams;
 use OrangeHRM\OpenidAuthentication\Traits\Service\SocialMediaAuthenticationServiceTrait;
+use OrangeHRM\OpenidAuthentication\Utility\OIDCUrlValidator;
 use OrangeHRM\ORM\Exception\TransactionException;
 
 class ProviderAPI extends Endpoint implements CrudEndpoint
@@ -276,11 +277,7 @@ class ProviderAPI extends Endpoint implements CrudEndpoint
                 $this->getNameRule($this->getOpenIdProviderCommonUniqueOption()),
             ),
             $this->getValidationDecorator()->requiredParamRule(
-                new ParamRule(
-                    self::PARAMETER_URL,
-                    new Rule(Rules::STRING_TYPE),
-                    new Rule(Rules::LENGTH, [null , self::PARAM_RULE_PROVIDER_URL_MAX_LENGTH])
-                ),
+                $this->getProviderUrlParamRule(),
                 true
             ),
             $this->getValidationDecorator()->requiredParamRule(
@@ -304,6 +301,35 @@ class ProviderAPI extends Endpoint implements CrudEndpoint
                 )
             ),
         );
+    }
+
+    /**
+     * Provider URL rule: string + max length + an SSRF guard that rejects non-http(s) schemes and
+     * hosts resolving to private/reserved addresses, so an internal URL can never be persisted as a
+     * provider (clean 422). The runtime fetch is independently guarded by the OIDC HTTP client.
+     *
+     * @return ParamRule
+     */
+    protected function getProviderUrlParamRule(): ParamRule
+    {
+        return new ParamRule(
+            self::PARAMETER_URL,
+            new Rule(Rules::STRING_TYPE),
+            new Rule(Rules::LENGTH, [null, self::PARAM_RULE_PROVIDER_URL_MAX_LENGTH]),
+            new Rule(Rules::CALLBACK, [
+                function ($url): bool {
+                    return $this->getUrlValidator()->isAllowedProviderUrl((string)$url);
+                }
+            ])
+        );
+    }
+
+    /**
+     * @return OIDCUrlValidator
+     */
+    protected function getUrlValidator(): OIDCUrlValidator
+    {
+        return new OIDCUrlValidator();
     }
 
     /**
@@ -501,11 +527,7 @@ class ProviderAPI extends Endpoint implements CrudEndpoint
                 $this->getNameRule($uniqueOption),
             ),
             $this->getValidationDecorator()->requiredParamRule(
-                new ParamRule(
-                    self::PARAMETER_URL,
-                    new Rule(Rules::STRING_TYPE),
-                    new Rule(Rules::LENGTH, [null , self::PARAM_RULE_PROVIDER_URL_MAX_LENGTH])
-                ),
+                $this->getProviderUrlParamRule(),
                 true
             ),
             $this->getValidationDecorator()->requiredParamRule(

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/Utility/OIDCUrlValidator.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/Utility/OIDCUrlValidator.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OrangeHRM.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OrangeHRM\OpenidAuthentication\Utility;
+
+use OrangeHRM\Core\Traits\Service\ConfigServiceTrait;
+
+/**
+ * Write-time guard for OIDC provider URLs (SSRF hardening).
+ *
+ * A provider URL is allowed only when its scheme is http/https and every address its host resolves
+ * to is a public, routable address. The public/private decision uses PHP's built-in
+ * filter_var(FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE), which
+ * rejects loopback, RFC1918 private, link-local (incl. the 169.254.169.254 cloud-metadata address)
+ * and reserved ranges — no hand-maintained CIDR list. All resolved A/AAAA records are checked.
+ *
+ * Admins running an OIDC provider on an internal network (e.g. self-hosted Keycloak) can relax the
+ * private-address rejection via the `oidc.allow_private_provider_hosts` config (default off); the
+ * http/https scheme requirement is always enforced.
+ */
+class OIDCUrlValidator
+{
+    use ConfigServiceTrait;
+
+    /**
+     * @param string $url
+     * @return bool true when the URL is safe to persist (and later fetch server-side)
+     */
+    public function isAllowedProviderUrl(string $url): bool
+    {
+        $scheme = strtolower((string)parse_url($url, PHP_URL_SCHEME));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
+        $host = (string)parse_url($url, PHP_URL_HOST);
+        if ($host === '') {
+            return false;
+        }
+
+        if ($this->arePrivateHostsAllowed()) {
+            return true;
+        }
+
+        // Strip brackets from IPv6 literals (e.g. [::1]).
+        if (strlen($host) > 1 && $host[0] === '[' && substr($host, -1) === ']') {
+            $host = substr($host, 1, -1);
+        }
+
+        $ips = $this->resolveHostToIps($host);
+        if (empty($ips)) {
+            return false;
+        }
+
+        foreach ($ips as $ip) {
+            $isPublic = filter_var(
+                $ip,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            );
+            if ($isPublic === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool whether provider URLs resolving to private/internal addresses are allowed
+     */
+    protected function arePrivateHostsAllowed(): bool
+    {
+        return $this->getConfigService()->isOidcPrivateProviderHostAllowed();
+    }
+
+    /**
+     * Resolve a host (or accept an IP literal) to all of its A/AAAA records. Isolated for testability.
+     *
+     * @param string $host
+     * @return string[]
+     */
+    protected function resolveHostToIps(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        $ips = [];
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+        if (is_array($records)) {
+            foreach ($records as $record) {
+                if (!empty($record['ip'])) {
+                    $ips[] = $record['ip'];
+                }
+                if (!empty($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        if (empty($ips)) {
+            $byName = @gethostbynamel($host);
+            if (is_array($byName)) {
+                $ips = $byName;
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+}

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/test/Utility/OIDCUrlValidatorTest.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/test/Utility/OIDCUrlValidatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OrangeHRM.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OrangeHRM\Tests\OpenidAuthentication\Utility;
+
+use OrangeHRM\OpenidAuthentication\Utility\OIDCUrlValidator;
+use OrangeHRM\Tests\Util\TestCase;
+
+/**
+ * SSRF guard for OIDC provider URLs: scheme allowlist + rejection of any host resolving to a
+ * private/reserved/loopback/link-local/metadata/CGNAT address (unless the admin opt-out is on).
+ *
+ * @group OpenIDAuth
+ */
+class OIDCUrlValidatorTest extends TestCase
+{
+    /**
+     * Literal IPs (and scheme-only checks) need no DNS resolution; the opt-out is off here.
+     *
+     * @dataProvider literalUrlProvider
+     */
+    public function testIsAllowedProviderUrlWithLiterals(string $url, bool $expected): void
+    {
+        $this->assertSame($expected, $this->validator()->isAllowedProviderUrl($url));
+    }
+
+    public function literalUrlProvider(): array
+    {
+        return [
+            'public ipv4 https' => ['https://93.184.216.34/', true],
+            'public ipv4 http' => ['http://93.184.216.34:8443/', true],
+            'public ipv6' => ['https://[2606:2800:220:1:248:1893:25c8:1946]/', true],
+            'ftp scheme' => ['ftp://93.184.216.34/', false],
+            'file scheme' => ['file:///etc/passwd', false],
+            'gopher scheme' => ['gopher://93.184.216.34/', false],
+            'no scheme' => ['93.184.216.34', false],
+            'garbage' => ['not a url', false],
+            'loopback' => ['http://127.0.0.1/', false],
+            'metadata' => ['http://169.254.169.254/latest/meta-data/', false],
+            'rfc1918 10' => ['http://10.0.0.1/', false],
+            'rfc1918 172' => ['http://172.16.5.4/', false],
+            'rfc1918 192' => ['http://192.168.1.1/', false],
+            'all zeros' => ['http://0.0.0.0/', false],
+            'ipv6 loopback' => ['http://[::1]/', false],
+            'ipv6 link local' => ['http://[fe80::1]/', false],
+        ];
+    }
+
+    public function testHostResolvingOnlyToPublicIsAllowed(): void
+    {
+        $this->assertTrue(
+            $this->validator(['93.184.216.34'])->isAllowedProviderUrl('https://idp.example.com/')
+        );
+    }
+
+    public function testHostResolvingToAnyPrivateIsRejected(): void
+    {
+        // DNS-rebinding shape: a mix of public and private records must be rejected.
+        $this->assertFalse(
+            $this->validator(['93.184.216.34', '10.0.0.5'])->isAllowedProviderUrl('https://rebind.example.com/')
+        );
+    }
+
+    public function testHostThatDoesNotResolveIsRejected(): void
+    {
+        $this->assertFalse($this->validator([])->isAllowedProviderUrl('https://nonexistent.example.com/'));
+    }
+
+    public function testPrivateHostAllowedWhenOptOutEnabled(): void
+    {
+        // With the admin opt-out on, an internal IdP host is allowed...
+        $this->assertTrue(
+            $this->validator(['10.0.0.5'], true)->isAllowedProviderUrl('https://keycloak.internal/')
+        );
+        // ...but a non-http(s) scheme is still rejected regardless of the opt-out.
+        $this->assertFalse(
+            $this->validator(['10.0.0.5'], true)->isAllowedProviderUrl('ftp://keycloak.internal/')
+        );
+    }
+
+    /**
+     * Validator with DNS resolution and the config opt-out stubbed, so tests stay offline.
+     *
+     * @param string[]|null $stubIps null = resolve literally (IP hosts only); array = forced records
+     * @param bool $allowPrivate
+     * @return OIDCUrlValidator
+     */
+    private function validator(?array $stubIps = null, bool $allowPrivate = false): OIDCUrlValidator
+    {
+        return new class ($stubIps, $allowPrivate) extends OIDCUrlValidator {
+            /** @var string[]|null */
+            private ?array $stubIps;
+            private bool $allowPrivate;
+
+            public function __construct(?array $stubIps, bool $allowPrivate)
+            {
+                $this->stubIps = $stubIps;
+                $this->allowPrivate = $allowPrivate;
+            }
+
+            protected function arePrivateHostsAllowed(): bool
+            {
+                return $this->allowPrivate;
+            }
+
+            protected function resolveHostToIps(string $host): array
+            {
+                return $this->stubIps ?? parent::resolveHostToIps($host);
+            }
+        };
+    }
+}

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/test/fixtures/testcases/ProviderAPITestCases.yaml
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/test/fixtures/testcases/ProviderAPITestCases.yaml
@@ -129,13 +129,13 @@ Update:
       id: 1
     body:
       name: 'Azure AD'
-      url: 'https://azure.auth.com'
+      url: 'https://93.184.216.34/'
       clientId: '6f2182cc5083a84083b'
       clientSecret: '0f0cc6f83baf5f43c609ec9752'
     data:
       id: 1
       providerName: 'Azure AD'
-      providerUrl: 'https://azure.auth.com'
+      providerUrl: 'https://93.184.216.34/'
       status: true
       clientId: '6f2182cc5083a84083b'
 
@@ -147,7 +147,7 @@ Update:
       id: 100
     body:
       name: 'Azure AD'
-      url: 'https://azure.auth.com'
+      url: 'https://93.184.216.34/'
       status: true
       clientId: '6f2182cc5083a84083b'
       clientSecret: '0f0cc6f83baf5f43c609ec9752'
@@ -163,7 +163,7 @@ Update:
       id: 1
     body:
       name: null
-      url: 'https://azure.auth.com'
+      url: 'https://93.184.216.34/'
       status: true
       clientId: '6f2182cc5083a84083b'
       clientSecret: '0f0cc6f83baf5f43c609ec9752'
@@ -178,12 +178,38 @@ Create:
       oidc.social_media_auth_service: \OrangeHRM\OpenidAuthentication\Service\SocialMediaAuthenticationService
     body:
       name: 'Azure'
-      url: 'https://azure.auth.com'
+      url: 'https://93.184.216.34/'
       clientId: '6f2182cc5083a84083b'
       clientSecret: '0f0cc6f2182cc5083a84083baf5f43c609ec9752'
     data:
       id: 5
       providerName: 'Azure'
-      providerUrl: 'https://azure.auth.com'
+      providerUrl: 'https://93.184.216.34/'
       status: true
       clientId: '6f2182cc5083a84083b'
+
+  'Create Auth Provider - blocked internal URL':
+    userId: 1
+    services:
+      oidc.social_media_auth_service: \OrangeHRM\OpenidAuthentication\Service\SocialMediaAuthenticationService
+    body:
+      name: 'Internal SSRF'
+      url: 'http://169.254.169.254/latest/meta-data/'
+      clientId: '6f2182cc5083a84083b'
+      clientSecret: '0f0cc6f2182cc5083a84083baf5f43c609ec9752'
+    exception:
+      class: '\OrangeHRM\Core\Api\V2\Exception\InvalidParamException'
+      message: 'Invalid Parameter'
+
+  'Create Auth Provider - blocked non-http scheme':
+    userId: 1
+    services:
+      oidc.social_media_auth_service: \OrangeHRM\OpenidAuthentication\Service\SocialMediaAuthenticationService
+    body:
+      name: 'Bad Scheme'
+      url: 'ftp://93.184.216.34/'
+      clientId: '6f2182cc5083a84083b'
+      clientSecret: '0f0cc6f2182cc5083a84083baf5f43c609ec9752'
+    exception:
+      class: '\OrangeHRM\Core\Api\V2\Exception\InvalidParamException'
+      message: 'Invalid Parameter'


### PR DESCRIPTION
## Validate OIDC provider URL at write time to prevent SSRF

### Problem
`POST/PUT /api/v2/auth/openid-providers` accepted an arbitrary provider URL with only
string-type and max-length validation — no scheme allowlist, no host restrictions. OrangeHRM
then performs server-side OIDC discovery against that URL, so an admin (or anyone able to write
the provider config) could coerce the server into requests to internal hosts or cloud metadata
(`169.254.169.254`) — a blind SSRF.

### Fix (write-time validation)
Reject internal/non-http provider URLs at registration so they can never be persisted — kept
deliberately small, using PHP built-ins (no new dependency, no hand-maintained CIDR list):

- **`OIDCUrlValidator`** — allows only `http`/`https` URLs whose host resolves **entirely** to
  public addresses, via PHP's built-in
  `filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)`
  (loopback, RFC1918, link-local incl. the `169.254.169.254` metadata address, and reserved
  ranges), checked across **all** resolved A/AAAA records.
- **`ProviderAPI`** create/update wire the check via `Rules::CALLBACK`, returning a clean 422.
- **Admin opt-out** — `ConfigService` `oidc.allow_private_provider_hosts` (default **off**,
  secure) lets admins running an OIDC provider on an internal network (e.g. self-hosted Keycloak)
  allow private hosts. The `http/https` scheme requirement always applies. The absent key already
  reads as off; a **`V5_9_0` installer migration** seeds `'No'` (only when missing, so it never
  resets an admin's value) to make the setting discoverable in `hs_hr_config` on fresh installs
  and upgrades.

### Tests
- `OIDCUrlValidatorTest` — scheme allowlist; private/reserved/IPv6 literals rejected; public
  IPv4/IPv6 allowed; DNS-rebinding (mixed public+private resolution) rejected; opt-out path.
- `ProviderAPITestCases` adds blocked internal-URL and non-http-scheme create cases.
- Migration verified to run idempotently (seeds `No`, does not overwrite an existing value).
- `php-cs-fix` and `generate-open-api-doc --throw` clean.

### Scope note
This is the write-time control. It does not add a runtime DNS-rebinding guard or change the OIDC
login/discovery flow, keeping the change minimal and low-risk for the supported public providers.

### QA scope
**Regression:** add/edit + full SSO login for each supported public provider (Google,
Microsoft/Azure, Okta, Auth0, public Keycloak) — saving and login unaffected.
**Internal IdP:** with the opt-out off (default), a provider whose host resolves to a private IP
is rejected at save (422); setting `oidc.allow_private_provider_hosts = Yes` allows it (non-http
schemes still rejected).
**Security:** save attempts for `127.0.0.1`, `169.254.169.254`, `10.x`, `172.16.x`, `192.168.x`,
`[::1]`, `[fe80::1]`, and `ftp/file/gopher` schemes all return 422 and persist nothing; a hostname
resolving to any private address (incl. mixed public+private) is rejected.
**Install/upgrade:** fresh install and upgrade from 5.8.1 both seed the `oidc.allow_private_provider_hosts`
row as `No`; behaviour is unchanged (still blocked) whether the row is present or absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
