### PR TITLE
OHRM5X-2664: Add PHP 8.5 support

### DIFF
--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
 
       - name: Install dependencies
         run: |
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
 
     services:
       mysql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,20 @@ jobs:
           php -f /usr/bin/composer install
           php -f /usr/bin/composer dump-autoload -o
 
+      - name: Set up PHP 8.5
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+
+      - name: Install depandancies on PHP 8.5
+        run: |
+          cd src
+          rm -rf vendor
+          php -v
+          php -f /usr/bin/composer validate --strict
+          php -f /usr/bin/composer install
+          php -f /usr/bin/composer dump-autoload -o
+
   installation:
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04

--- a/installer/config/system_requirements.php
+++ b/installer/config/system_requirements.php
@@ -20,7 +20,7 @@
 return [
     'phpversion' => [
         'min' => '7.4',
-        'max' => '8.4',
+        'max' => '8.5',
         'excludeRange' => [],
     ],
 


### PR DESCRIPTION
Raise the installer's supported PHP ceiling from 8.4 to 8.5 and add PHP 8.5 to the CI matrices so the runtime is validated on every build.

- installer/config/system_requirements.php: phpversion max 8.4 -> 8.5 (the version check trims the running version to the max's precision, so '8.5' accepts 8.5.x)
- .github/workflows/scheduled_test.yml: add 8.5 to the php matrix and run the DB-version coverage job on 8.5 (the newest supported PHP)
- .github/workflows/test.yml: add an 8.5 cross-version composer install/validate leg alongside the existing 8.3 and 8.4 legs

Verified locally on the php-8.5 dev container (PHP 8.5.7): composer install resolves for src and devTools/core, and the full PHPUnit suite (4929 tests) shows no regressions versus the 8.4 baseline (identical 189 errors; 107 vs 108 failures, all pre-existing environmental auth-seeding failures) and zero runtime deprecation notices.