### PR TITLE
OHRM5X-2662: Validate sendmail path instead of URL-encoding it

### DIFF
--- a/src/plugins/orangehrmCorePlugin/Utility/MailTransport.php
+++ b/src/plugins/orangehrmCorePlugin/Utility/MailTransport.php
@@ -24,6 +24,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 class MailTransport extends AbstractTransport
@@ -77,8 +78,10 @@ class MailTransport extends AbstractTransport
     public function __construct(string $scheme = self::SCHEME_SMTP, string $host = 'localhost', ?int $port = null)
     {
         if ($scheme == self::SCHEME_SENDMAIL) {
-            $dsn = 'sendmail://default?command='.urlencode($host);
-            $this->mailTransport = Transport::fromDsn($dsn);
+            if (!preg_match('#^/[a-zA-Z0-9./_-]+(\s+-[a-zA-Z]{1,3})*$#', $host)) {
+                throw new \InvalidArgumentException('Invalid sendmail path');
+            }
+            $this->mailTransport = new SendmailTransport($host);
         } elseif ($scheme == self::SCHEME_SMTP || $scheme == self::SCHEME_SECURE_SMTP) {
             $this->scheme = $scheme;
             $this->host = $host;

--- a/src/plugins/orangehrmCorePlugin/test/Utility/MailTransportTest.php
+++ b/src/plugins/orangehrmCorePlugin/test/Utility/MailTransportTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OrangeHRM.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OrangeHRM\Tests\Core\Utility;
+
+use OrangeHRM\Core\Utility\MailTransport;
+use OrangeHRM\Tests\Util\TestCase;
+use ReflectionClass;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+
+/**
+ * @group Core
+ * @group Utility
+ */
+class MailTransportTest extends TestCase
+{
+    public function testConstructWithValidSendmailPathCreatesSendmailTransport(): void
+    {
+        $path = '/usr/sbin/sendmail -bs';
+        $mailTransport = new MailTransport(MailTransport::SCHEME_SENDMAIL, $path);
+
+        $inner = $this->getInnerTransport($mailTransport);
+        $this->assertInstanceOf(SendmailTransport::class, $inner);
+        // The configured path must reach the transport verbatim, with no
+        // URL-encoding/decoding round-trip mangling it.
+        $this->assertSame($path, $this->getCommand($inner));
+    }
+
+    /**
+     * @dataProvider invalidSendmailPathDataProvider
+     */
+    public function testConstructWithInvalidSendmailPathThrowsException(string $maliciousPath): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid sendmail path');
+        new MailTransport(MailTransport::SCHEME_SENDMAIL, $maliciousPath);
+    }
+
+    public function invalidSendmailPathDataProvider(): array
+    {
+        return [
+            'command injection with semicolon' => ['/usr/sbin/sendmail -bs; rm -rf /'],
+            'command substitution' => ['/usr/sbin/sendmail -bs $(touch /tmp/x)'],
+            'pipe injection' => ['/usr/sbin/sendmail | curl evil.test'],
+            'url-encoded injection' => ['/usr/sbin/sendmail%20-bs%3Brm'],
+            'not an absolute path' => ['sendmail -bs'],
+            'backtick injection' => ['/usr/sbin/sendmail `id`'],
+        ];
+    }
+
+    private function getInnerTransport(MailTransport $mailTransport): object
+    {
+        $reflection = new ReflectionClass(MailTransport::class);
+        $property = $reflection->getProperty('mailTransport');
+        $property->setAccessible(true);
+        return $property->getValue($mailTransport);
+    }
+
+    private function getCommand(SendmailTransport $transport): string
+    {
+        $reflection = new ReflectionClass(SendmailTransport::class);
+        $property = $reflection->getProperty('command');
+        $property->setAccessible(true);
+        return $property->getValue($transport);
+    }
+}


### PR DESCRIPTION
## What

Replace the ineffective `urlencode()` sanitization of the sendmail command path in `MailTransport` with explicit input validation.

## Why

`MailTransport::__construct()` built a DSN and parsed it:

```php
$dsn = 'sendmail://default?command='.urlencode($host);
$this->mailTransport = Transport::fromDsn($dsn);
```

`Transport::fromDsn()` → `Dsn::fromString()` internally calls `parse_str()`, which **URL-decodes** query values — reverting the `urlencode()` before the value reaches the transport. The encoding provided no protection: a payload like `/usr/sbin/sendmail -bs; rm -rf /` survived the round-trip unchanged.

Not currently exploitable (the path comes from internal, non-user-facing config), but encoding-as-sanitization is the wrong control. This is a defense-in-depth hardening.

## How

```php
if ($scheme == self::SCHEME_SENDMAIL) {
    if (!preg_match('#^/[a-zA-Z0-9./_-]+(\s+-[a-zA-Z]{1,3})*$#', $host)) {
        throw new \InvalidArgumentException('Invalid sendmail path');
    }
    $this->mailTransport = new SendmailTransport($host);
}
```

- Validates `$host`: absolute path of safe characters, optionally followed by short `-xx` flags (e.g. `-bs`, `-t`). Shell metacharacters (`;`, `|`, `` ` ``, `$(...)`) and non-absolute paths are rejected.
- Constructs `SendmailTransport` directly — no DSN round-trip to undo the check.
- Default configured path `/usr/sbin/sendmail -bs` passes the regex.

## Testing (TDD)

Added `MailTransportTest` first (red → green):

- Valid path → produces a `SendmailTransport` whose command equals the input verbatim (no encode/decode mangling).
- Six injection payloads (semicolon, `$(...)`, pipe, URL-encoded, non-absolute, backtick) → each throws `InvalidArgumentException`.

Results: new test `OK (7 tests, 14 assertions)`; existing `EmailServiceTest` still `OK (10 tests)`; `php-cs-fix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
