### PR TITLE
OHRM5X-2661: Block SSRF via OIDC provider URL with request-time egress filter

### DIFF
--- a/installer/Migration/V5_9_0/Migration.php
+++ b/installer/Migration/V5_9_0/Migration.php
@@ -36,6 +36,7 @@ class Migration extends AbstractMigration
         $this->getDataGroupHelper()->insertScreenPermissions(__DIR__ . '/permission/screen.yaml');
         $this->getDataGroupHelper()->insertApiPermissions(__DIR__ . '/permission/api.yaml');
         $this->insertWorkspaceNotificationMenuItem();
+        $this->insertOidcAllowPrivateProviderHostsConfig();
 
         $this->getLangStringHelper()->insertOrUpdateLangStrings(__DIR__, 'admin');
     }
@@ -142,6 +143,27 @@ class Migration extends AbstractMigration
     }
 
     private const CONFIG_KEY_WORKSPACE_ENABLED = 'workspace.notifications.enabled';
+    private const CONFIG_KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS = 'oidc.allow_private_provider_hosts';
+
+    private function insertOidcAllowPrivateProviderHostsConfig(): void
+    {
+        $exists = $this->createQueryBuilder()
+            ->select('config.name')
+            ->from('hs_hr_config', 'config')
+            ->where('config.name = :name')
+            ->setParameter('name', self::CONFIG_KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS)
+            ->executeQuery()
+            ->fetchOne();
+
+        if ($exists === false) {
+            $this->createQueryBuilder()
+                ->insert('hs_hr_config')
+                ->values(['name' => ':name', 'value' => ':value'])
+                ->setParameter('name', self::CONFIG_KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS)
+                ->setParameter('value', '0')
+                ->executeQuery();
+        }
+    }
 
     private function insertWorkspaceNotificationMenuItem(): void
     {

--- a/src/composer.json
+++ b/src/composer.json
@@ -41,6 +41,7 @@
         "phpseclib/phpseclib": "~3.0.37",
         "symfony/ldap": "~5.4.45",
         "symfony/console": "~5.4.47",
+        "symfony/http-client": "~5.4.45",
         "crunzphp/crunz": "~3.4.1",
         "bjeavons/zxcvbn-php": "~1.3.1",
         "league/oauth2-server": "~8.4.2",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9f6a66eae6951ea8e908515b703d2a1",
+    "content-hash": "46df7aac74387ae6042d9de26c909fdf",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -4100,6 +4100,179 @@
                 }
             ],
             "time": "2024-01-23T13:51:25+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v5.4.53",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "b9bb0c36216de55c64c4cc904fab1c3e8765a996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/b9bb0c36216de55c64c4cc904fab1c3e8765a996",
+                "reference": "b9bb0c36216de55c64c4cc904fab1c3e8765a996",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/http-client-contracts": "^2.5.4",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.0|^2|^3"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "2.4"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "php-http/message-factory": "^1.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4.13|^5.1.5|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v5.4.53"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-22T10:25:12+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v2.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "48ef1d0a082885877b664332b9427662065a360c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/48ef1d0a082885877b664332b9427662065a360c",
+                "reference": "48ef1d0a082885877b664332b9427662065a360c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-28T08:37:04+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -8494,5 +8667,5 @@
         "ext-openssl": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/plugins/orangehrmCorePlugin/Service/ConfigService.php
+++ b/src/plugins/orangehrmCorePlugin/Service/ConfigService.php
@@ -47,6 +47,7 @@ class ConfigService
     public const KEY_ADMIN_DEFAULT_WORKSHIFT_START_TIME = 'admin.default_workshift_start_time';
     public const KEY_ADMIN_DEFAULT_WORKSHIFT_END_TIME = 'admin.default_workshift_end_time';
     public const KEY_OPENID_PROVIDER_ADDED = 'openId.provider.added';
+    public const KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS = 'oidc.allow_private_provider_hosts';
     public const KEY_OPEN_SOURCE_INTEGRATIONS = 'open_source_integrations';
     public const KEY_INSTANCE_IDENTIFIER = 'instance.identifier';
     public const KEY_SENDMAIL_PATH = 'email_config.sendmail_path';
@@ -535,6 +536,17 @@ class ConfigService
     public function showSystemCheckScreen(): bool
     {
         return $this->_getConfigValue(self::KEY_SHOW_SYSTEM_CHECK_SCREEN) == 1;
+    }
+
+    /**
+     * Whether OIDC provider URLs resolving to private/internal addresses are allowed.
+     * Off by default; the request-time SSRF guard only relaxes when this is explicitly enabled.
+     *
+     * @return bool
+     */
+    public function isOidcPrivateProviderHostAllowed(): bool
+    {
+        return $this->_getConfigValue(self::KEY_OIDC_ALLOW_PRIVATE_PROVIDER_HOSTS) == 1;
     }
 
     /**

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/Api/ProviderAPI.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/Api/ProviderAPI.php
@@ -276,11 +276,7 @@ class ProviderAPI extends Endpoint implements CrudEndpoint
                 $this->getNameRule($this->getOpenIdProviderCommonUniqueOption()),
             ),
             $this->getValidationDecorator()->requiredParamRule(
-                new ParamRule(
-                    self::PARAMETER_URL,
-                    new Rule(Rules::STRING_TYPE),
-                    new Rule(Rules::LENGTH, [null , self::PARAM_RULE_PROVIDER_URL_MAX_LENGTH])
-                ),
+                $this->getProviderUrlParamRule(),
                 true
             ),
             $this->getValidationDecorator()->requiredParamRule(
@@ -303,6 +299,24 @@ class ProviderAPI extends Endpoint implements CrudEndpoint
                     new Rule(Rules::BOOL_TYPE)
                 )
             ),
+        );
+    }
+
+    /**
+     * Write-time format guard for the provider URL: a well-formed http(s) URL within the
+     * length limit. This is UX/defence-in-depth only — the private/internal-address SSRF
+     * decision is enforced at request time by {@see \OrangeHRM\OpenidAuthentication\OpenID\OpenIDConnectClient}.
+     *
+     * @return ParamRule
+     */
+    protected function getProviderUrlParamRule(): ParamRule
+    {
+        return new ParamRule(
+            self::PARAMETER_URL,
+            new Rule(Rules::STRING_TYPE),
+            new Rule(Rules::LENGTH, [null, self::PARAM_RULE_PROVIDER_URL_MAX_LENGTH]),
+            new Rule(Rules::URL),
+            new Rule(Rules::REGEX, ['/^https?:\/\//i'])
         );
     }
 
@@ -501,11 +515,7 @@ class ProviderAPI extends Endpoint implements CrudEndpoint
                 $this->getNameRule($uniqueOption),
             ),
             $this->getValidationDecorator()->requiredParamRule(
-                new ParamRule(
-                    self::PARAMETER_URL,
-                    new Rule(Rules::STRING_TYPE),
-                    new Rule(Rules::LENGTH, [null , self::PARAM_RULE_PROVIDER_URL_MAX_LENGTH])
-                ),
+                $this->getProviderUrlParamRule(),
                 true
             ),
             $this->getValidationDecorator()->requiredParamRule(

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/OpenID/OpenIDConnectClient.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/OpenID/OpenIDConnectClient.php
@@ -19,13 +19,37 @@
 
 namespace OrangeHRM\OpenidAuthentication\OpenID;
 
+use Jumbojett\OpenIDConnectClientException;
 use OrangeHRM\Core\Traits\Auth\AuthUserTrait;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 
 class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
 {
     use AuthUserTrait;
 
     protected ?string $generatedAuthUrl = null;
+
+    /**
+     * When false (default) every server-side OIDC request is routed through
+     * {@see NoPrivateNetworkHttpClient}, which rejects any hop resolving to a private,
+     * loopback, link-local (incl. 169.254.169.254 cloud metadata) or reserved address —
+     * the SSRF guard. Admins running a provider on an internal network can opt out.
+     */
+    protected bool $allowPrivateProviderHosts = false;
+
+    protected ?int $httpResponseCode = null;
+
+    protected ?string $httpResponseContentType = null;
+
+    /**
+     * @param bool $allow
+     */
+    public function setAllowPrivateProviderHosts(bool $allow): void
+    {
+        $this->allowPrivateProviderHosts = $allow;
+    }
 
     /**
      * @inheritDoc
@@ -72,5 +96,75 @@ class OpenIDConnectClient extends \Jumbojett\OpenIDConnectClient
     protected function unsetSessionKey(string $key)
     {
         $this->getAuthUser()->removeAttribute($key);
+    }
+
+    /**
+     * Replaces the library's raw cURL transport with Symfony HttpClient so that every
+     * outbound OIDC request (discovery, token, JWKS, userinfo) — and every redirect hop —
+     * is screened by {@see NoPrivateNetworkHttpClient} unless an admin has opted out.
+     *
+     * @inheritDoc
+     */
+    protected function fetchURL(string $url, ?string $post_body = null, array $headers = [])
+    {
+        $method = 'GET';
+        $requestHeaders = $headers;
+        $requestHeaders[] = 'User-Agent: ' . $this->getUserAgent();
+
+        $options = [
+            'max_redirects' => 20,
+            'timeout' => $this->getTimeout(),
+            'max_duration' => $this->getTimeout(),
+            'verify_peer' => $this->getVerifyPeer(),
+            'verify_host' => $this->getVerifyHost(),
+        ];
+
+        if ($post_body !== null) {
+            $method = 'POST';
+            $contentType = is_object(json_decode($post_body, false))
+                ? 'application/json'
+                : 'application/x-www-form-urlencoded';
+            $requestHeaders[] = "Content-Type: $contentType";
+            $options['body'] = $post_body;
+        }
+
+        $options['headers'] = $requestHeaders;
+
+        $certPath = $this->getCertPath();
+        if (!empty($certPath)) {
+            $options['cafile'] = $certPath;
+        }
+
+        $client = HttpClient::create();
+        if (!$this->allowPrivateProviderHosts) {
+            $client = new NoPrivateNetworkHttpClient($client);
+        }
+
+        try {
+            $response = $client->request($method, $url, $options);
+            $this->httpResponseCode = $response->getStatusCode();
+            $contentTypeHeader = $response->getHeaders(false)['content-type'][0] ?? null;
+            $this->httpResponseContentType = $contentTypeHeader;
+
+            return $response->getContent(false);
+        } catch (HttpClientExceptionInterface $e) {
+            throw new OpenIDConnectClientException($e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResponseCode(): int
+    {
+        return (int) $this->httpResponseCode;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getResponseContentType()
+    {
+        return $this->httpResponseContentType;
     }
 }

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/Service/SocialMediaAuthenticationService.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/Service/SocialMediaAuthenticationService.php
@@ -26,6 +26,7 @@ use OrangeHRM\Authentication\Exception\AuthenticationException;
 use OrangeHRM\Authentication\Service\AuthenticationService;
 use OrangeHRM\Authentication\Traits\Service\AuthenticationServiceTrait;
 use OrangeHRM\Core\Traits\Auth\AuthUserTrait;
+use OrangeHRM\Core\Traits\Service\ConfigServiceTrait;
 use OrangeHRM\Core\Utility\EncryptionHelperTrait;
 use OrangeHRM\Entity\AuthProviderExtraDetails;
 use OrangeHRM\Entity\EmployeeTerminationRecord;
@@ -45,6 +46,7 @@ class SocialMediaAuthenticationService
     use AuthenticationServiceTrait;
     use EncryptionHelperTrait;
     use AuthUserTrait;
+    use ConfigServiceTrait;
 
     private AuthenticationService $authenticationService;
     private AuthProviderDao $authProviderDao;
@@ -87,6 +89,9 @@ class SocialMediaAuthenticationService
 
         $oidcClient->addScope([$scope]);
         $oidcClient->setRedirectURL($redirectUrl);
+        $oidcClient->setAllowPrivateProviderHosts(
+            $this->getConfigService()->isOidcPrivateProviderHostAllowed()
+        );
 
         return $oidcClient;
     }

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/test/OpenID/OpenIDConnectClientTest.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/test/OpenID/OpenIDConnectClientTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * OrangeHRM is a comprehensive Human Resource Management (HRM) System that captures
+ * all the essential functionalities required for any enterprise.
+ * Copyright (C) 2006 OrangeHRM Inc., http://www.orangehrm.com
+ *
+ * OrangeHRM is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * OrangeHRM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with OrangeHRM.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace OrangeHRM\Tests\OpenidAuthentication\OpenID;
+
+use Jumbojett\OpenIDConnectClientException;
+use OrangeHRM\OpenidAuthentication\OpenID\OpenIDConnectClient;
+use OrangeHRM\Tests\Util\TestCase;
+
+/**
+ * @group OpenIDAuth
+ */
+class OpenIDConnectClientTest extends TestCase
+{
+    /**
+     * Exposes the protected transport so SSRF egress behaviour can be asserted directly.
+     */
+    private function getClient(string $providerUrl): OpenIDConnectClient
+    {
+        return new class ($providerUrl, 'client-id', 'client-secret') extends OpenIDConnectClient {
+            public function exposedFetchURL(string $url, ?string $postBody = null, array $headers = [])
+            {
+                return $this->fetchURL($url, $postBody, $headers);
+            }
+        };
+    }
+
+    /**
+     * @dataProvider blockedTargetProvider
+     */
+    public function testFetchUrlBlocksRequestsToPrivateOrInternalTargets(string $url): void
+    {
+        $client = $this->getClient($url);
+
+        $this->expectException(OpenIDConnectClientException::class);
+        $this->expectExceptionMessageMatches('/blocked/i');
+
+        $client->exposedFetchURL($url);
+    }
+
+    public function blockedTargetProvider(): array
+    {
+        return [
+            'loopback IPv4' => ['http://127.0.0.1:19877/.well-known/openid-configuration'],
+            'cloud metadata' => ['http://169.254.169.254/latest/meta-data/'],
+            'private RFC1918' => ['http://10.0.0.5/.well-known/openid-configuration'],
+            'loopback hostname' => ['http://localhost:8080/.well-known/openid-configuration'],
+        ];
+    }
+
+    /**
+     * With the admin opt-out enabled, the private-network egress filter must not be applied:
+     * the request fails for ordinary connection reasons, never with a "blocked" rejection.
+     */
+    public function testFetchUrlAllowsPrivateTargetsWhenOptedIn(): void
+    {
+        $client = $this->getClient('http://127.0.0.1:19877');
+        $client->setAllowPrivateProviderHosts(true);
+
+        try {
+            $client->exposedFetchURL('http://127.0.0.1:19877/.well-known/openid-configuration');
+            $this->fail('Expected a transport failure connecting to a closed port.');
+        } catch (OpenIDConnectClientException $e) {
+            $this->assertStringNotContainsStringIgnoringCase('blocked', $e->getMessage());
+        }
+    }
+}

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/test/Service/SocialMediaAuthenticationServiceTest.php
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/test/Service/SocialMediaAuthenticationServiceTest.php
@@ -56,6 +56,8 @@ class SocialMediaAuthenticationServiceTest extends KernelTestCase
 
     public function testInitiateAuthentication(): void
     {
+        $this->createKernelWithMockServices([Services::CONFIG_SERVICE => new ConfigService()]);
+
         $provider = $this->socialMediaAuthenticationService->getAuthProviderDao()->getAuthProviderDetailsByProviderId(1);
         $scope = 'email';
         $redirectUrl = 'https://accounts.google.com/auth';

--- a/src/plugins/orangehrmOpenidAuthenticationPlugin/test/fixtures/testcases/ProviderAPITestCases.yaml
+++ b/src/plugins/orangehrmOpenidAuthenticationPlugin/test/fixtures/testcases/ProviderAPITestCases.yaml
@@ -187,3 +187,45 @@ Create:
       providerUrl: 'https://azure.auth.com'
       status: true
       clientId: '6f2182cc5083a84083b'
+
+  'Create Auth Provider - Okta vendor URL':
+    userId: 1
+    services:
+      oidc.social_media_auth_service: \OrangeHRM\OpenidAuthentication\Service\SocialMediaAuthenticationService
+    body:
+      name: 'Okta'
+      url: 'https://dev-12345678.okta.com/oauth2/default'
+      clientId: '0oa1b2c3d4e5f6g7h8i9'
+      clientSecret: 'aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcd'
+    data:
+      id: 5
+      providerName: 'Okta'
+      providerUrl: 'https://dev-12345678.okta.com/oauth2/default'
+      status: true
+      clientId: '0oa1b2c3d4e5f6g7h8i9'
+
+  'Create Auth Provider - non-http scheme rejected':
+    userId: 1
+    services:
+      oidc.social_media_auth_service: \OrangeHRM\OpenidAuthentication\Service\SocialMediaAuthenticationService
+    body:
+      name: 'Evil'
+      url: 'file:///etc/passwd'
+      clientId: '6f2182cc5083a84083b'
+      clientSecret: '0f0cc6f2182cc5083a84083baf5f43c609ec9752'
+    exception:
+      class: '\OrangeHRM\Core\Api\V2\Exception\InvalidParamException'
+      message: 'Invalid Parameter'
+
+  'Create Auth Provider - malformed URL rejected':
+    userId: 1
+    services:
+      oidc.social_media_auth_service: \OrangeHRM\OpenidAuthentication\Service\SocialMediaAuthenticationService
+    body:
+      name: 'Broken'
+      url: 'not-a-url'
+      clientId: '6f2182cc5083a84083b'
+      clientSecret: '0f0cc6f2182cc5083a84083baf5f43c609ec9752'
+    exception:
+      class: '\OrangeHRM\Core\Api\V2\Exception\InvalidParamException'
+      message: 'Invalid Parameter'


### PR DESCRIPTION
## Issue
Mantis **0067173** — Blind SSRF via OIDC provider URL configuration. The provider `url` (`POST`/`PUT /api/v2/auth/openid-providers`) was validated only for string type + length. The public login-trigger flow (`/openidauth/openIdCredentials/{providerId}`) makes the server fetch `{url}/.well-known/openid-configuration` (and token/JWKS/userinfo) via the Jumbojett client, so the URL could point at internal hosts, loopback, or cloud-metadata (`169.254.169.254`).

## Fix
Enforcement is at **request time** — the only sound boundary, since Jumbojett follows redirects and a write-time check can't stop DNS rebinding or a redirect to an internal address.

- **Request-time egress filter:** `OpenIDConnectClient::fetchURL()` now routes every OIDC fetch through Symfony's maintained **`NoPrivateNetworkHttpClient`**, which rejects private/loopback/link-local/reserved targets on each request **and each redirect hop**. New dep `symfony/http-client ~5.4.45`. No hand-maintained CIDR list — the library owns it.
- **Response getters:** parent `$responseCode`/`$responseContentType` are private, so the subclass also overrides `getResponseCode()`/`getResponseContentType()` — required, or `requestUserInfo()` (asserts status === 200) would break login for every vendor.
- **Write-time rule (UX/defence-in-depth):** `ProviderAPI::getProviderUrlParamRule()` adds respect/validation `Url` + an `http(s)` scheme regex. No IP logic here.
- **Admin opt-out:** off-by-default `oidc.allow_private_provider_hosts` (`ConfigService::isOidcPrivateProviderHostAllowed()`), seeded `'0'` in the existing `V5_9_0` migration, wired in at the single client-construction site. Keeps self-hosted internal Keycloak working.

## Supported vendors
Verified the write-time rule accepts Google / Microsoft / Okta / Auth0 / Keycloak (cloud **and** internal-http) and rejects `file://`, `gopher://`, `javascript:`, `not-a-url`; and confirmed **live** that Google's real discovery returns 200 through the active filter. Only behavioural change for a legit deployment is self-hosted internal providers, preserved via the opt-out.

## Tests (TDD)
- **New** `test/OpenID/OpenIDConnectClientTest.php` — red phase proved the bug (the old code actually connected to 127.0.0.1 / 10.0.0.5 / 169.254.169.254 / localhost); green after the filter (blocked offline, suite drops from ~2 min to 0.01s). Includes the opt-out-bypass case.
- `ProviderAPITestCases.yaml` — added an accepted Okta URL case + rejected `file://` / `not-a-url` cases.
- `php-cs-fix` clean; `php -l` clean on all changed files.

> Note: the OIDC endpoint **integration** tests can't run in the local dev container (pre-existing `doctrine.entity_manager` not-found, affecting unmodified cases too); the new YAML cases run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)